### PR TITLE
COMPASS-3605: allow query_expression to have agg_array expressions

### DIFF
--- a/src/agg_pipeline.pegjs
+++ b/src/agg_pipeline.pegjs
@@ -794,7 +794,7 @@ id "_id" = '_id' / "'_id'" { return '_id' } / '"_id"' { return '_id' }
 expression = bson_types / number / string / boolean / null / array / object / regex_literal
 
 // Expression that can include query operators
-query_expression = query_object / query_array / expression
+query_expression = query_object / query_array / expression / agg_array
 
 // Expression that can include aggregation operators
 agg_expression = agg_object / agg_array / expression

--- a/test/accepts.spec.js
+++ b/test/accepts.spec.js
@@ -333,998 +333,1033 @@ describe('#accepts', () => {
           '         }' +
           '}');
       });
+      it('supports multiple pipeline', () => {
+        accepts('{$lookup:' +
+          '{\n' +
+          '  from: "air_airlines",\n' +
+          '  let: { maybe_name: "$airlines" },\n' +
+          '  pipeline: [\n' +
+          '    { $match:\n' +
+          '      { $expr:\n' +
+          '        { $gt:\n' +
+          '          [ \n' +
+          '            { $size: { $setIntersection: [ "$$maybe_name", ["$name", "$alias", "$iata", "$icao"] ] } },\n' +
+          '            0\n' +
+          '          ]\n' +
+          '        }\n' +
+          '      }\n' +
+          '    },\n' +
+          '    { $project:\n' +
+          '      {\n' +
+          '        _id: 0,\n' +
+          '        name_is: "$name",\n' +
+          '        ref_name:\n' +
+          '          { $arrayElemAt:\n' +
+          '            [\n' +
+          '              { $filter:\n' +
+          '                { input: "$$maybe_name", cond: { $in: ["$$this", ["$name", "$alias", "$iata", "$icao"]] } }\n' +
+          '              },\n' +
+          '              0\n' +
+          '            ]\n' +
+          '          }\n' +
+          '      }\n' +
+          '    }\n' +
+          '  ],\n' +
+          '  as: "found"\n' +
+          '         }' +
+          '}');
+      });
     });
 
     describe('$geoNear', () => {
       it('accepts full doc', () => {
         accepts(
           '{$geoNear: {' +
-            'minDistance: 10.1,' +
-            'distanceField: "toField",' +
+          'minDistance: 10.1,' +
+          'distanceField: "toField",' +
+          'spherical: true,' +
+          'limit: 100,' +
+          'num: 100,' +
+          'uniqueDocs: true,' +
+          'maxDistance: 100,' +
+          'key: "location",' +
+          'query: {x: 1},' +
+          'distanceMultiplier: 100,' +
+          'includeLocs: "outputfield",' +
+          'near: {type: "Point", coordinates: [10.01, 9.99]}' +
+          '}}');
+        it('rejects a doc without near', () => {
+          rejects(
+            '{$geoNear: {' +
             'spherical: true,' +
             'limit: 100,' +
             'num: 100,' +
-            'uniqueDocs: true,' +
             'maxDistance: 100,' +
-            'key: "location",' +
             'query: {x: 1},' +
             'distanceMultiplier: 100,' +
+            'uniqueDocs: true,' +
+            'distanceField: "toField",' +
             'includeLocs: "outputfield",' +
-            'near: {type: "Point", coordinates: [10.01, 9.99]}' +
-          '}}');
-      });
-      it('rejects a doc without near', () => {
-        rejects(
-          '{$geoNear: {' +
-          'spherical: true,' +
-          'limit: 100,' +
-          'num: 100,' +
-          'maxDistance: 100,' +
-          'query: {x: 1},' +
-          'distanceMultiplier: 100,' +
-          'uniqueDocs: true,' +
-          'distanceField: "toField",' +
-          'includeLocs: "outputfield",' +
-          'minDistance: 10.1' +
-          '}}');
-      });
-      it('rejects a doc without distanceField', () => {
-        rejects(
-          '{$geoNear: {' +
-          'spherical: true,' +
-          'limit: 100,' +
-          'num: 100,' +
-          'maxDistance: 100,' +
-          'query: {x: 1},' +
-          'distanceMultiplier: 100,' +
-          'uniqueDocs: true,' +
-          'includeLocs: "outputfield",' +
-          'minDistance: 10.1' +
-          'near: false,' +
-          '}}');
-      });
-      it('accepts the two required', () => {
-        accepts(
-          '{$geoNear: { ' +
-          'near: {type: "Point", coordinates: [10.01, 9.99]},' +
-          'distanceField: "field" } }'
-        );
-      });
-      it('rejects the two required if type wrong', () => {
-        rejects(
-          '{$geoNear: { near: 1, distanceField: 1 } }'
-        );
-      });
-      it('rejects if query not a document', () => {
-        rejects(
-          '{$geoNear: { near: true, distanceField: "field", query: 1 } }'
-        );
-      });
-
-      describe('near', () => {
-        it('rejects non-point geoJSON for near', () => {
-          rejects(
-            '{$geoNear: { ' +
-            'near: ' +
-            '{ type: "LineString", coordinates: [ [ 40, 5 ], [ 41, 6 ] ] }' +
-            ', distanceField: "field" } }'
-          );
+            'minDistance: 10.1' +
+            '}}');
         });
-        it('rejects bad geoJSON', () => {
+        it('rejects a doc without distanceField', () => {
           rejects(
+            '{$geoNear: {' +
+            'spherical: true,' +
+            'limit: 100,' +
+            'num: 100,' +
+            'maxDistance: 100,' +
+            'query: {x: 1},' +
+            'distanceMultiplier: 100,' +
+            'uniqueDocs: true,' +
+            'includeLocs: "outputfield",' +
+            'minDistance: 10.1' +
+            'near: false,' +
+            '}}');
+        });
+        it('accepts the two required', () => {
+          accepts(
             '{$geoNear: { ' +
-            'near: {type: "Point", coordinates: [ -9.99 ]},' +
+            'near: {type: "Point", coordinates: [10.01, 9.99]},' +
             'distanceField: "field" } }'
           );
         });
-        it('rejects non-geoJSON for near', () => {
+        it('rejects the two required if type wrong', () => {
           rejects(
-            '{$geoNear: { ' +
-            'near: ' +
-            '{ x: 1}' +
-            ', distanceField: "field" } }'
+            '{$geoNear: { near: 1, distanceField: 1 } }'
           );
         });
-        it('accepts legacy coordinates', () => {
-          accepts(
-            '{$geoNear: { ' +
-            'near: ' +
-            '[ 10.0001, -33.900 ]' +
-            ', distanceField: "field" } }'
-          );
-        });
-        it('rejects bad legacy coordinates', () => {
+        it('rejects if query not a document', () => {
           rejects(
-            '{$geoNear: { ' +
-            'near: ' +
-            '[ -33.900 ]' +
-            ', distanceField: "field" } }'
+            '{$geoNear: { near: true, distanceField: "field", query: 1 } }'
           );
         });
-      });
-    });
 
-    describe('$group', () => {
-      it('accepts a group with _id', () => {
-        accepts('{ $group: { _id: 1, field1: { $sum: "field" } } }');
+        describe('near', () => {
+          it('rejects non-point geoJSON for near', () => {
+            rejects(
+              '{$geoNear: { ' +
+              'near: ' +
+              '{ type: "LineString", coordinates: [ [ 40, 5 ], [ 41, 6 ] ] }' +
+              ', distanceField: "field" } }'
+            );
+          });
+          it('rejects bad geoJSON', () => {
+            rejects(
+              '{$geoNear: { ' +
+              'near: {type: "Point", coordinates: [ -9.99 ]},' +
+              'distanceField: "field" } }'
+            );
+          });
+          it('rejects non-geoJSON for near', () => {
+            rejects(
+              '{$geoNear: { ' +
+              'near: ' +
+              '{ x: 1}' +
+              ', distanceField: "field" } }'
+            );
+          });
+          it('accepts legacy coordinates', () => {
+            accepts(
+              '{$geoNear: { ' +
+              'near: ' +
+              '[ 10.0001, -33.900 ]' +
+              ', distanceField: "field" } }'
+            );
+          });
+          it('rejects bad legacy coordinates', () => {
+            rejects(
+              '{$geoNear: { ' +
+              'near: ' +
+              '[ -33.900 ]' +
+              ', distanceField: "field" } }'
+            );
+          });
+        });
       });
-      it('accepts a group with $mergeObjects', () => {
-        accepts('{ $group: { _id: 1, field1: { $mergeObjects: "field" } } }');
-      });
-      it('rejects a group without _id', () => {
-        rejects('{ $group: { field1: { $sum: "field" } } }');
-      });
-      it('rejects an empty group', () => {
-        rejects('{ $group: {} }');
-      });
-      it('rejects a group that is not an accumulator', () => {
-        rejects('{ $group: { _id: 1, field1: 1 } }');
-      });
-      it('accepts an agg expr for _id', () => {
-        accepts('{ $group: { _id: {$abs: 1}, field1: { $sum: "field" } } }');
-      });
-      it('accepts an agg expr for accumulator', () => {
-        accepts('{ $group: { _id: {$abs: 1}, field1: { $sum: {$abs: 1} } } }');
-      });
-    });
 
-    describe('$graphLookup', () => {
-      it('accepts min doc', () => {
-        accepts('{$graphLookup: {' +
-          'from: "employees",' +
-          'startWith: "$reportsTo",' +
-          'connectFromField: "reportsTo",' +
-          'connectToField: "name",' +
-          'as: "reportingHierarchy"' +
-          '}}');
+      describe('$group', () => {
+        it('accepts a group with _id', () => {
+          accepts('{ $group: { _id: 1, field1: { $sum: "field" } } }');
+        });
+        it('accepts a group with $mergeObjects', () => {
+          accepts('{ $group: { _id: 1, field1: { $mergeObjects: "field" } } }');
+        });
+        it('rejects a group without _id', () => {
+          rejects('{ $group: { field1: { $sum: "field" } } }');
+        });
+        it('rejects an empty group', () => {
+          rejects('{ $group: {} }');
+        });
+        it('rejects a group that is not an accumulator', () => {
+          rejects('{ $group: { _id: 1, field1: 1 } }');
+        });
+        it('accepts an agg expr for _id', () => {
+          accepts('{ $group: { _id: {$abs: 1}, field1: { $sum: "field" } } }');
+        });
+        it('accepts an agg expr for accumulator', () => {
+          accepts('{ $group: { _id: {$abs: 1}, field1: { $sum: {$abs: 1} } } }');
+        });
       });
-      it('accepts full doc', () => {
-        accepts('{$graphLookup: {' +
-          'from: "employees",' +
-          'startWith: "$reportsTo",' +
-          'connectFromField: "reportsTo",' +
-          'connectToField: "name",' +
-          'as: "reportingHierarchy",' +
-          'maxDepth: 100,' +
-          'depthField: "fieldname",' +
-          'restrictSearchWithMatch: {x: 1}' +
-          '}}');
-      });
-      it('accepts an expression for startWith', () => {
-        accepts('{$graphLookup: {' +
-          'from: "employees",' +
-          'startWith: {$abs: 1},' +
-          'connectFromField: "reportsTo",' +
-          'connectToField: "name",' +
-          'as: "reportingHierarchy"' +
-          '}}');
-      });
-      it('accepts an array for startWith', () => {
-        accepts('{$graphLookup: {' +
-          'from: "employees",' +
-          'startWith: ["f1", "f2"],' +
-          'connectFromField: "reportsTo",' +
-          'connectToField: "name",' +
-          'as: "reportingHierarchy"' +
-          '}}');
-      });
-      it('accepts an array for connectToField', () => {
-        accepts('{$graphLookup: {' +
-          'from: "employees",' +
-          'startWith: ["f1", "f2"],' +
-          'connectFromField: "reportsTo",' +
-          'connectToField: ["name", "name2"],' +
-          'as: "reportingHierarchy"' +
-          '}}');
-      });
-      it('accepts query expr for restrictSearchWithMatch', () => {
-        accepts('{$graphLookup: { from: "employees", startWith: "$reportsTo",' +
-          'connectFromField: "reportsTo", connectToField: "name", ' +
-          'as: "reportingHierarchy", restrictSearchWithMatch: {x: {$gt: 1}}}}');
-      });
-      it('rejects agg expr for restrictSearchWithMatch', () => {
-        rejects('{$graphLookup: { from: "employees", startWith: "$reportsTo",' +
-          'connectFromField: "reportsTo", connectToField: "name",' +
-          'as: "reportingHierarchy", restrictSearchWithMatch: {x: {$literal: 1}}}}');
-      });
-      it('accepts a regular doc', () => {
-        accepts('{$graphLookup: { from: "employees", startWith: "$reportsTo",' +
-          'connectFromField: "reportsTo", connectToField: "name",' +
-          'as: "reportingHierarchy",' +
-          'restrictSearchWithMatch: {x: 1}}}');
-        accepts('{$graphLookup: { from: "employees", startWith: "$reportsTo",' +
-          'connectFromField: "reportsTo", connectToField: "name",' +
-          'as: "reportingHierarchy",' +
-          'restrictSearchWithMatch: {"x": 1}}}');
-      });
-    });
 
-    describe('$bucket', () => {
-      it('accepts min doc', () => {
-        accepts('{$bucket: {' +
-          'groupBy: "$fieldname",' +
-          'boundaries: [1,2],' +
-          '}}');
+      describe('$graphLookup', () => {
+        it('accepts min doc', () => {
+          accepts('{$graphLookup: {' +
+            'from: "employees",' +
+            'startWith: "$reportsTo",' +
+            'connectFromField: "reportsTo",' +
+            'connectToField: "name",' +
+            'as: "reportingHierarchy"' +
+            '}}');
+        });
+        it('accepts full doc', () => {
+          accepts('{$graphLookup: {' +
+            'from: "employees",' +
+            'startWith: "$reportsTo",' +
+            'connectFromField: "reportsTo",' +
+            'connectToField: "name",' +
+            'as: "reportingHierarchy",' +
+            'maxDepth: 100,' +
+            'depthField: "fieldname",' +
+            'restrictSearchWithMatch: {x: 1}' +
+            '}}');
+        });
+        it('accepts an expression for startWith', () => {
+          accepts('{$graphLookup: {' +
+            'from: "employees",' +
+            'startWith: {$abs: 1},' +
+            'connectFromField: "reportsTo",' +
+            'connectToField: "name",' +
+            'as: "reportingHierarchy"' +
+            '}}');
+        });
+        it('accepts an array for startWith', () => {
+          accepts('{$graphLookup: {' +
+            'from: "employees",' +
+            'startWith: ["f1", "f2"],' +
+            'connectFromField: "reportsTo",' +
+            'connectToField: "name",' +
+            'as: "reportingHierarchy"' +
+            '}}');
+        });
+        it('accepts an array for connectToField', () => {
+          accepts('{$graphLookup: {' +
+            'from: "employees",' +
+            'startWith: ["f1", "f2"],' +
+            'connectFromField: "reportsTo",' +
+            'connectToField: ["name", "name2"],' +
+            'as: "reportingHierarchy"' +
+            '}}');
+        });
+        it('accepts query expr for restrictSearchWithMatch', () => {
+          accepts('{$graphLookup: { from: "employees", startWith: "$reportsTo",' +
+            'connectFromField: "reportsTo", connectToField: "name", ' +
+            'as: "reportingHierarchy", restrictSearchWithMatch: {x: {$gt: 1}}}}');
+        });
+        it('rejects agg expr for restrictSearchWithMatch', () => {
+          rejects('{$graphLookup: { from: "employees", startWith: "$reportsTo",' +
+            'connectFromField: "reportsTo", connectToField: "name",' +
+            'as: "reportingHierarchy", restrictSearchWithMatch: {x: {$literal: 1}}}}');
+        });
+        it('accepts a regular doc', () => {
+          accepts('{$graphLookup: { from: "employees", startWith: "$reportsTo",' +
+            'connectFromField: "reportsTo", connectToField: "name",' +
+            'as: "reportingHierarchy",' +
+            'restrictSearchWithMatch: {x: 1}}}');
+          accepts('{$graphLookup: { from: "employees", startWith: "$reportsTo",' +
+            'connectFromField: "reportsTo", connectToField: "name",' +
+            'as: "reportingHierarchy",' +
+            'restrictSearchWithMatch: {"x": 1}}}');
+        });
       });
-      it('accepts an agg expr for groupBy', () => {
-        accepts('{$bucket: {' +
-          'groupBy: {$abs: 1},' +
-          'boundaries: [1,2],' +
-          '}}');
-      });
-      it('accepts full doc', () => {
-        accepts('{$bucket: {' +
-          'groupBy: "$fieldname",' +
-          'boundaries: [1,2],' +
-          'default: "a string",' +
-          'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
-          '}}');
-      });
-      it('accepts literal in boundaries', () => {
-        accepts('{$bucket: {' +
-          'groupBy: "$fieldname",' +
-          'boundaries: [{$literal: {x:1}}, {$literal: {x:2}}],' +
-          'default: "a string",' +
-          'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
-          '}}');
-      });
-      it('rejects without required fields', () => {
-        rejects('{$bucket: {' +
-          'boundaries: [1,2],' +
-          'default: "a string",' +
-          'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
-          '}}');
-      });
-      it('accepts test doc', () => {
-        accepts('{' +
-          '$bucket: {' +
-          '    groupBy: "$price",' +
-          '    boundaries: [ 0, 150, 200, 300, 400 ],' +
-          '    default: "Other",' +
-          '    output: {' +
-          '        "count": { $sum: 1 },' +
-          '        "titles": { $push: "$title" }' +
-          '    }' +
-          '}' +
-          '}');
-      });
-      it('rejects a $ in output field', () => {
-        rejects('{$bucket: {' +
-          'groupBy: "$fieldname",' +
-          'boundaries: [{$literal: {x:1}}, {$literal: {x:2}}],' +
-          'default: "a string",' +
-          'output: { $output1: {$sum: 1}, output2: {$avg: 1} }' +
-          '}}');
-      });
-    });
 
-    describe('$bucketAuto', () => {
-      it('accepts min doc', () => {
-        accepts('{$bucketAuto: {' +
-          'groupBy: "$fieldname",' +
-          'buckets: 10' +
-          '}}');
-      });
-      it('accepts an agg expr for groupBy', () => {
-        accepts('{$bucketAuto: {' +
-          'groupBy: {$abs: 1},' +
-          'buckets: 10' +
-          '}}');
-      });
-      it('accepts full doc', () => {
-        accepts('{$bucketAuto: {' +
-          'groupBy: "$fieldname",' +
-          'buckets: 10,' +
-          'granularity: "R80",' +
-          'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
-          '}}');
-      });
-      it('accepts literal in boundaries', () => {
-        accepts('{$bucketAuto: {' +
-          'groupBy: "$fieldname",' +
-          'buckets: 10,' +
-          'granularity: "R80",' +
-          'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
-          '}}');
-      });
-      it('rejects without required fields', () => {
-        rejects('{$bucketAuto: {' +
-          'buckets: 10,' +
-          'granularity: "R80",' +
-          'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
-          '}}');
-      });
-    });
-
-    // Expressions that have defined fields that can be more than one type
-    describe('$unwind', () => {
-      it('accepts a field path', () => {
-        accepts('{ $unwind: "$fieldpath" }');
-      });
-      it('rejects without $', () => {
-        rejects('{ $unwind: "fieldpath" }');
-      });
-      it('accepts full document', () => {
-        accepts('{ $unwind: ' +
-          '{ path: "$fieldpath",' +
-          '  includeArrayIndex: "newField",' +
-          '   preserveNullAndEmptyArrays: false }' +
-          '}');
-      });
-      it('rejects includeArrayIndex with $', () => {
-        rejects('{ $unwind: ' +
-          '{ path: "$fieldpath",' +
-          '  includeArrayIndex: "$newField",' +
-          '   preserveNullAndEmptyArrays: false }' +
-          '}');
-      });
-      it('accepts document with only path', () => {
-        rejects('{ $unwind: ' +
-          '{ path: "$fieldpath"' +
-          '}');
-      });
-    });
-
-    // TODO: supported in compass?
-    describe('$listLocalSessions', () => {
-      it('accepts an empty doc', () => {
-        accepts('{$listLocalSessions: {}}');
-      });
-      it('accepts allUsers', () => {
-        accepts('{$listLocalSessions: {allUsers: true}}');
-      });
-      it('accepts one user/db', () => {
-        accepts('{$listLocalSessions: {users: [' +
-          '{user: "anna", db:"test"}' +
-          ']}}');
-      });
-      it('accepts multiple user/db', () => {
-        accepts('{$listLocalSessions: {users: [' +
-          '{user: "anna", db:"test"}, {user: "sara", db: "test2"}' +
-          ']}}');
-      });
-    });
-
-    describe('$listSessions', () => {
-      it('accepts an empty doc', () => {
-        accepts('{$listSessions: {}}');
-      });
-      it('accepts allUsers', () => {
-        accepts('{$listSessions: {allUsers: true}}');
-      });
-      it('accepts one user/db', () => {
-        accepts('{$listSessions: {users: [' +
-          '{user: "anna", db:"test"}' +
-          ']}}');
-      });
-      it('accepts multiple user/db', () => {
-        accepts('{$listSessions: {users: [' +
-          '{user: "anna", db:"test"}, {user: "sara", db: "test2"}' +
-          ']}}');
-      });
-    });
-
-    // Expressions without predefined fields
-    describe('$addFields', () => {
-      it('accepts multiple fields', () => {
-        accepts('{$addFields: {' +
-          'field1: "value1",' +
-          'field2: 1,' +
-          '"field3": {x: 1},' +
-          '}}');
-      });
-      it('accepts one field', () => {
-        accepts('{$addFields: {' +
-          'field1: "value1"' +
-          '}}');
-      });
-      it('rejects empty', () => {
-        rejects('{$addFields: {' +
-          '}}');
-      });
-      it('rejects non-doc', () => {
-        rejects('{$addField: "test"}');
-      });
-      it('accepts agg expr', () => {
-        accepts('{$addFields: {' +
-          'field1: {$abs: 100},' +
-          '}}');
-        it('accepts a nested field', () => {
-          accepts('{$addFields: {' +
-            '   field1.subfield: {$abs: 100},' +
+      describe('$bucket', () => {
+        it('accepts min doc', () => {
+          accepts('{$bucket: {' +
+            'groupBy: "$fieldname",' +
+            'boundaries: [1,2],' +
+            '}}');
+        });
+        it('accepts an agg expr for groupBy', () => {
+          accepts('{$bucket: {' +
+            'groupBy: {$abs: 1},' +
+            'boundaries: [1,2],' +
+            '}}');
+        });
+        it('accepts full doc', () => {
+          accepts('{$bucket: {' +
+            'groupBy: "$fieldname",' +
+            'boundaries: [1,2],' +
+            'default: "a string",' +
+            'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
+            '}}');
+        });
+        it('accepts literal in boundaries', () => {
+          accepts('{$bucket: {' +
+            'groupBy: "$fieldname",' +
+            'boundaries: [{$literal: {x:1}}, {$literal: {x:2}}],' +
+            'default: "a string",' +
+            'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
+            '}}');
+        });
+        it('rejects without required fields', () => {
+          rejects('{$bucket: {' +
+            'boundaries: [1,2],' +
+            'default: "a string",' +
+            'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
+            '}}');
+        });
+        it('accepts test doc', () => {
+          accepts('{' +
+            '$bucket: {' +
+            '    groupBy: "$price",' +
+            '    boundaries: [ 0, 150, 200, 300, 400 ],' +
+            '    default: "Other",' +
+            '    output: {' +
+            '        "count": { $sum: 1 },' +
+            '        "titles": { $push: "$title" }' +
+            '    }' +
+            '}' +
+            '}');
+        });
+        it('rejects a $ in output field', () => {
+          rejects('{$bucket: {' +
+            'groupBy: "$fieldname",' +
+            'boundaries: [{$literal: {x:1}}, {$literal: {x:2}}],' +
+            'default: "a string",' +
+            'output: { $output1: {$sum: 1}, output2: {$avg: 1} }' +
             '}}');
         });
       });
 
-      context('when supplying conversion operators', () => {
-        it('accepts $convert', () => {
-          accepts('{$addFields: { name: { $convert: { input: true, to: "int"}}}}');
+      describe('$bucketAuto', () => {
+        it('accepts min doc', () => {
+          accepts('{$bucketAuto: {' +
+            'groupBy: "$fieldname",' +
+            'buckets: 10' +
+            '}}');
         });
-
-        it('accepts $toBool', () => {
-          accepts('{$addFields: { name: { $toBool: true }}}');
+        it('accepts an agg expr for groupBy', () => {
+          accepts('{$bucketAuto: {' +
+            'groupBy: {$abs: 1},' +
+            'buckets: 10' +
+            '}}');
         });
-
-        it('accepts $toDate', () => {
-          accepts('{$addFields: { name: { $toDate: true }}}');
+        it('accepts full doc', () => {
+          accepts('{$bucketAuto: {' +
+            'groupBy: "$fieldname",' +
+            'buckets: 10,' +
+            'granularity: "R80",' +
+            'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
+            '}}');
         });
-
-        it('accepts $toDecimal', () => {
-          accepts('{$addFields: { name: { $toDecimal: true }}}');
+        it('accepts literal in boundaries', () => {
+          accepts('{$bucketAuto: {' +
+            'groupBy: "$fieldname",' +
+            'buckets: 10,' +
+            'granularity: "R80",' +
+            'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
+            '}}');
         });
-
-        it('accepts $toDouble', () => {
-          accepts('{$addFields: { name: { $toDouble: true }}}');
-        });
-
-        it('accepts $toInt', () => {
-          accepts('{$addFields: { name: { $toInt: true }}}');
-        });
-
-        it('accepts $toLong', () => {
-          accepts('{$addFields: { name: { $toLong: true }}}');
-        });
-
-        it('accepts $toObjectId', () => {
-          accepts('{$addFields: { name: { $toObjectId: true }}}');
-        });
-
-        it('accepts $toString', () => {
-          accepts('{$addFields: { name: { $toString: true }}}');
-        });
-
-        it('accepts $ltrim', () => {
-          accepts('{$addFields: { name: { $ltrim: { input: "", chars: "" }}}}');
-        });
-
-        it('accepts $rtrim', () => {
-          accepts('{$addFields: { name: { $rtrim: { input: "", chars: "" }}}}');
-        });
-
-        it('accepts $trim', () => {
-          accepts('{$addFields: { name: { $trim: { input: "", chars: "" }}}}');
+        it('rejects without required fields', () => {
+          rejects('{$bucketAuto: {' +
+            'buckets: 10,' +
+            'granularity: "R80",' +
+            'output: { output1: {$sum: 1}, output2: {$avg: 1} }' +
+            '}}');
         });
       });
-    });
 
-    describe('$sort', () => {
-      it('accepts multiple fields', () => {
-        accepts('{$sort: {' +
-          'field1: 1,' +
-          'field2: -1,' +
-          'field3: {$meta: "textScore"},' +
-          '}}');
+      // Expressions that have defined fields that can be more than one type
+      describe('$unwind', () => {
+        it('accepts a field path', () => {
+          accepts('{ $unwind: "$fieldpath" }');
+        });
+        it('rejects without $', () => {
+          rejects('{ $unwind: "fieldpath" }');
+        });
+        it('accepts full document', () => {
+          accepts('{ $unwind: ' +
+            '{ path: "$fieldpath",' +
+            '  includeArrayIndex: "newField",' +
+            '   preserveNullAndEmptyArrays: false }' +
+            '}');
+        });
+        it('rejects includeArrayIndex with $', () => {
+          rejects('{ $unwind: ' +
+            '{ path: "$fieldpath",' +
+            '  includeArrayIndex: "$newField",' +
+            '   preserveNullAndEmptyArrays: false }' +
+            '}');
+        });
+        it('accepts document with only path', () => {
+          rejects('{ $unwind: ' +
+            '{ path: "$fieldpath"' +
+            '}');
+        });
       });
-      it('accepts meta sort order', () => {
-        accepts('{$sort: {' +
-          'field: {$meta: \'textScore\'}' +
-          '}}');
-      });
-      it('accepts one field', () => {
-        accepts('{$sort: {' +
-          'field: 1,' +
-          '}}');
-      });
-      it('rejects empty', () => {
-        rejects('{$sort: {' +
-          '}}');
-      });
-      it('rejects non-doc', () => {
-        rejects('{$sort: "test"}');
-      });
-      it('rejects sort number not 1/-1 order', () => {
-        rejects('{$sort: {' +
-          'field: 100' +
-          '}}');
-      });
-      it('rejects $meta without textScore order', () => {
-        rejects('{$sort: {' +
-          'field: {$meta: "notTextScore"' +
-          '}}');
-      });
-      it('rejects non $meta document', () => {
-        rejects('{$sort: {' +
-          'field: {$notmeta: "TextScore"' +
-          '}}');
-      });
-    });
 
-    describe('$match', () => {
-      it('accepts a simple document', () => {
-        accepts('{$match: {' +
-          'x: 1, y: {q: 1}, z: "testing"' +
-          '}}');
+      // TODO: supported in compass?
+      describe('$listLocalSessions', () => {
+        it('accepts an empty doc', () => {
+          accepts('{$listLocalSessions: {}}');
+        });
+        it('accepts allUsers', () => {
+          accepts('{$listLocalSessions: {allUsers: true}}');
+        });
+        it('accepts one user/db', () => {
+          accepts('{$listLocalSessions: {users: [' +
+            '{user: "anna", db:"test"}' +
+            ']}}');
+        });
+        it('accepts multiple user/db', () => {
+          accepts('{$listLocalSessions: {users: [' +
+            '{user: "anna", db:"test"}, {user: "sara", db: "test2"}' +
+            ']}}');
+        });
       });
-      it('accepts a nested field', () => {
-        accepts('{$match: {' +
-          '"x.y.z": 1, y: {q: 1}, z: "testing"' +
-          '}}');
+
+      describe('$listSessions', () => {
+        it('accepts an empty doc', () => {
+          accepts('{$listSessions: {}}');
+        });
+        it('accepts allUsers', () => {
+          accepts('{$listSessions: {allUsers: true}}');
+        });
+        it('accepts one user/db', () => {
+          accepts('{$listSessions: {users: [' +
+            '{user: "anna", db:"test"}' +
+            ']}}');
+        });
+        it('accepts multiple user/db', () => {
+          accepts('{$listSessions: {users: [' +
+            '{user: "anna", db:"test"}, {user: "sara", db: "test2"}' +
+            ']}}');
+        });
       });
-      it('accepts $or', () => {
-        accepts('{$match: {' +
-          '$or: [{x:1}, {y: 1}]' +
-          '}}');
+
+      // Expressions without predefined fields
+      describe('$addFields', () => {
+        it('accepts multiple fields', () => {
+          accepts('{$addFields: {' +
+            'field1: "value1",' +
+            'field2: 1,' +
+            '"field3": {x: 1},' +
+            '}}');
+        });
+        it('accepts one field', () => {
+          accepts('{$addFields: {' +
+            'field1: "value1"' +
+            '}}');
+        });
+        it('rejects empty', () => {
+          rejects('{$addFields: {' +
+            '}}');
+        });
+        it('rejects non-doc', () => {
+          rejects('{$addField: "test"}');
+        });
+        it('accepts agg expr', () => {
+          accepts('{$addFields: {' +
+            'field1: {$abs: 100},' +
+            '}}');
+          it('accepts a nested field', () => {
+            accepts('{$addFields: {' +
+              '   field1.subfield: {$abs: 100},' +
+              '}}');
+          });
+        });
+
+        context('when supplying conversion operators', () => {
+          it('accepts $convert', () => {
+            accepts('{$addFields: { name: { $convert: { input: true, to: "int"}}}}');
+          });
+
+          it('accepts $toBool', () => {
+            accepts('{$addFields: { name: { $toBool: true }}}');
+          });
+
+          it('accepts $toDate', () => {
+            accepts('{$addFields: { name: { $toDate: true }}}');
+          });
+
+          it('accepts $toDecimal', () => {
+            accepts('{$addFields: { name: { $toDecimal: true }}}');
+          });
+
+          it('accepts $toDouble', () => {
+            accepts('{$addFields: { name: { $toDouble: true }}}');
+          });
+
+          it('accepts $toInt', () => {
+            accepts('{$addFields: { name: { $toInt: true }}}');
+          });
+
+          it('accepts $toLong', () => {
+            accepts('{$addFields: { name: { $toLong: true }}}');
+          });
+
+          it('accepts $toObjectId', () => {
+            accepts('{$addFields: { name: { $toObjectId: true }}}');
+          });
+
+          it('accepts $toString', () => {
+            accepts('{$addFields: { name: { $toString: true }}}');
+          });
+
+          it('accepts $ltrim', () => {
+            accepts('{$addFields: { name: { $ltrim: { input: "", chars: "" }}}}');
+          });
+
+          it('accepts $rtrim', () => {
+            accepts('{$addFields: { name: { $rtrim: { input: "", chars: "" }}}}');
+          });
+
+          it('accepts $trim', () => {
+            accepts('{$addFields: { name: { $trim: { input: "", chars: "" }}}}');
+          });
+        });
       });
-      it('accepts $and', () => {
-        accepts('{$match: {' +
-          '$and: [{z: 30}, {r: 99}]' +
-          '}}');
+
+      describe('$sort', () => {
+        it('accepts multiple fields', () => {
+          accepts('{$sort: {' +
+            'field1: 1,' +
+            'field2: -1,' +
+            'field3: {$meta: "textScore"},' +
+            '}}');
+        });
+        it('accepts meta sort order', () => {
+          accepts('{$sort: {' +
+            'field: {$meta: \'textScore\'}' +
+            '}}');
+        });
+        it('accepts one field', () => {
+          accepts('{$sort: {' +
+            'field: 1,' +
+            '}}');
+        });
+        it('rejects empty', () => {
+          rejects('{$sort: {' +
+            '}}');
+        });
+        it('rejects non-doc', () => {
+          rejects('{$sort: "test"}');
+        });
+        it('rejects sort number not 1/-1 order', () => {
+          rejects('{$sort: {' +
+            'field: 100' +
+            '}}');
+        });
+        it('rejects $meta without textScore order', () => {
+          rejects('{$sort: {' +
+            'field: {$meta: "notTextScore"' +
+            '}}');
+        });
+        it('rejects non $meta document', () => {
+          rejects('{$sort: {' +
+            'field: {$notmeta: "TextScore"' +
+            '}}');
+        });
       });
-      it('accepts an empty document', () => {
-        accepts('{$match: {' +
-          '' +
-          '}}');
-      });
-      it('accepts accumulators within $or', () => {
-        accepts('{$match: {' +
+
+      describe('$match', () => {
+        it('accepts a simple document', () => {
+          accepts('{$match: {' +
+            'x: 1, y: {q: 1}, z: "testing"' +
+            '}}');
+        });
+        it('accepts a nested field', () => {
+          accepts('{$match: {' +
+            '"x.y.z": 1, y: {q: 1}, z: "testing"' +
+            '}}');
+        });
+        it('accepts $or', () => {
+          accepts('{$match: {' +
+            '$or: [{x:1}, {y: 1}]' +
+            '}}');
+        });
+        it('accepts $and', () => {
+          accepts('{$match: {' +
+            '$and: [{z: 30}, {r: 99}]' +
+            '}}');
+        });
+        it('accepts an empty document', () => {
+          accepts('{$match: {' +
+            '' +
+            '}}');
+        });
+        it('accepts accumulators within $or', () => {
+          accepts('{$match: {' +
             '$or: [' +
-              '{ score: { $gt: 70, $lt: 90 } },' +
-              '{ x: { $lt: 70 } }' +
+            '{ score: { $gt: 70, $lt: 90 } },' +
+            '{ x: { $lt: 70 } }' +
             ']' +
-          '}}');
-      });
-      it('accepts query operators', () => {
-        accepts('{ $match: { x: { $gt: 70 } } }');
-      });
-      it('rejects field paths with $', () => {
-        rejects('{ $match: { $x: 1 } }');
-      });
-      it('accepts all 3 top-level options', () => {
-        accepts('{' +
-          '$match: {' +
-          '$or: [ ' +
-          '{ score: { $gt: 70, $lt: 90 } },' +
-          '{ views: { $gte: 1000 } } ' +
-          '],' +
-          '$and: [ ' +
-          '{ score: { $gt: 70, $lt: 90 } },' +
-          '{ views: { $gte: 1000 } } ' +
-          '],' +
-          'value: { $exists: "x" }' +
-          '}' +
-          '}');
-      });
-      it('accepts $match with multiple ISODate operators and NumberInt', () => {
-        accepts('{' +
-          '$match: {' +
+            '}}');
+        });
+        it('accepts query operators', () => {
+          accepts('{ $match: { x: { $gt: 70 } } }');
+        });
+        it('rejects field paths with $', () => {
+          rejects('{ $match: { $x: 1 } }');
+        });
+        it('accepts all 3 top-level options', () => {
+          accepts('{' +
+            '$match: {' +
+            '$or: [ ' +
+            '{ score: { $gt: 70, $lt: 90 } },' +
+            '{ views: { $gte: 1000 } } ' +
+            '],' +
+            '$and: [ ' +
+            '{ score: { $gt: 70, $lt: 90 } },' +
+            '{ views: { $gte: 1000 } } ' +
+            '],' +
+            'value: { $exists: "x" }' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and NumberInt', () => {
+          accepts('{' +
+            '$match: {' +
             'device: NumberInt(55),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and NumberInt as string', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and NumberInt as string', () => {
+          accepts('{' +
+            '$match: {' +
             'device: NumberInt("55"),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and NumberDecimal with string', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and NumberDecimal with string', () => {
+          accepts('{' +
+            '$match: {' +
             'device: NumberDecimal("55.5"),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and NumberDecimal with decimal', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and NumberDecimal with decimal', () => {
+          accepts('{' +
+            '$match: {' +
             'device: NumberDecimal(55.5),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and NumberLong with string', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and NumberLong with string', () => {
+          accepts('{' +
+            '$match: {' +
             'device: NumberLong("555555555555555555555555"),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and NumberLong with decimal', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and NumberLong with decimal', () => {
+          accepts('{' +
+            '$match: {' +
             'device: NumberLong(5555555555555555555555555),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and MinKey', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and MinKey', () => {
+          accepts('{' +
+            '$match: {' +
             'device: MinKey(),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and MaxKey', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and MaxKey', () => {
+          accepts('{' +
+            '$match: {' +
             'device: MaxKey(),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and Undefined', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and Undefined', () => {
+          accepts('{' +
+            '$match: {' +
             'device: MaxKey(),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and Date', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and Date', () => {
+          accepts('{' +
+            '$match: {' +
             'device: Date("2014-01-01"),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and ISODate', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and ISODate', () => {
+          accepts('{' +
+            '$match: {' +
             'device: ISODate("2014-01-01"),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and Timestamp with no args', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and Timestamp with no args', () => {
+          accepts('{' +
+            '$match: {' +
             'device: Timestamp(),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and Timestamp and args', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and Timestamp and args', () => {
+          accepts('{' +
+            '$match: {' +
             'device: Timestamp(1231212312, 1),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and ObjectId', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and ObjectId', () => {
+          accepts('{' +
+            '$match: {' +
             'device: ObjectId("aksfjksdfhjfjgdasjfhgksd"),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with multiple ISODate operators and Binary', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with multiple ISODate operators and Binary', () => {
+          accepts('{' +
+            '$match: {' +
             'device: Binary("aksfjksdfhjfjgdasjfhgksd", 1),' +
             'ts: {' +
-              '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
-              '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
+            '$gte: ISODate("2018-10-04T18:30:00.000Z"),' +
+            '$lte: ISODate("2018-10-05T18:29:59.999Z")' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with complex $cond', () => {
-        accepts('{' +
-          '$match: {' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with complex $cond', () => {
+          accepts('{' +
+            '$match: {' +
             '$expr: {' +
-              '$eq: [' +
-                '"$field1",' +
-                '{' +
-                  '$cond: [' +
-                    '{' +
-                      '$eq: [' +
-                        '"$field2",' +
-                        '"XYZ"' +
-                      ']' +
-                    '},' +
-                    '"$field1",' +
-                    '"ABC"' +
-                  ']' +
-                '}' +
-              ']' +
+            '$eq: [' +
+            '"$field1",' +
+            '{' +
+            '$cond: [' +
+            '{' +
+            '$eq: [' +
+            '"$field2",' +
+            '"XYZ"' +
+            ']' +
+            '},' +
+            '"$field1",' +
+            '"ABC"' +
+            ']' +
             '}' +
-          '}' +
-        '}');
-      });
-      it('accepts $match with a $comment', () => {
-        accepts('{' +
-          '$match: {' +
+            ']' +
+            '}' +
+            '}' +
+            '}');
+        });
+        it('accepts $match with a $comment', () => {
+          accepts('{' +
+            '$match: {' +
             'name: "testing",' +
             '$comment: "looks good"' +
-          '}' +
-        '}');
+            '}' +
+            '}');
+        });
       });
-    });
 
-    describe('$project', () => {
-      it('accepts a included field', () => {
-        accepts('{$project: {' +
+      describe('$project', () => {
+        it('accepts a included field', () => {
+          accepts('{$project: {' +
             'testfield: 1,' +
             'testfield2: true' +
-          '}}');
+            '}}');
+        });
+        it('accepts a excluded field', () => {
+          accepts('{$project: {' +
+            'testfield: 0,' +
+            'testfield: false,' +
+            '}}');
+        });
+        it('accepts a excluded _id field', () => {
+          accepts('{$project: {' +
+            '_id: 0,' +
+            '}}');
+        });
+        it('accepts an agg expr', () => {
+          accepts('{$project: {' +
+            '   field: {"$literal": "testing"},' +
+            '}}');
+        });
+        it('rejects an arbitrary $ field', () => { // TODO: limit to defined operators
+          rejects('{$project: {' +
+            'field: {"$testing": "testing"},' +
+            '}}');
+        });
+        it('accepts nested field', () => {
+          accepts('{$project: {' +
+            '"field.nested": "$new.field.name",' +
+            '}}');
+        });
+        it('accepts nested field without quotes', () => {
+          accepts('{$project: {' +
+            'field.nested: {"$literal": "testing"},' +
+            '}}');
+        });
+        it('accepts fields with whitespace', () => {
+          accepts('{$project: {' +
+            '"    fie   ld.nm   ested    ": "$new.field.name",' +
+            '}}');
+        });
+        it('accepts backslashes', () => {
+          accepts('{$project: {' +
+            '"field\?": "$new.field.name",' +
+            '}}');
+        });
+        it('rejects empty doc', () => {
+          rejects('{$project: {}}');
+        });
+        it('rejects both excluding and including fields', () => {
+          rejects('{$project: {field: true, field2: false}}');
+        });
+        it('accepts excluding id and including other field', () => {
+          accepts('{$project: {field: true, _id: false}}');
+        });
+        it('accepts a cond exclude', () => {
+          accepts('{\n' +
+            '      $project: {\n' +
+            '         title: 1,\n' +
+            '         "author.first": 1,\n' +
+            '         "author.last" : 1,\n' +
+            '         "author.middle": {\n' +
+            '            $cond: {\n' +
+            '               if: { $eq: [ "", "$author.middle" ] },\n' +
+            '               then: "$$REMOVE",\n' +
+            '               else: "$author.middle"\n' +
+            '            }\n' +
+            '         }\n' +
+            '      }\n' +
+            '   }');
+        });
       });
-      it('accepts a excluded field', () => {
-        accepts('{$project: {' +
-          'testfield: 0,' +
-          'testfield: false,' +
-          '}}');
-      });
-      it('accepts a excluded _id field', () => {
-        accepts('{$project: {' +
-          '_id: 0,' +
-          '}}');
-      });
-      it('accepts an agg expr', () => {
-        accepts('{$project: {' +
-          '   field: {"$literal": "testing"},' +
-          '}}');
-      });
-      it('rejects an arbitrary $ field', () => { // TODO: limit to defined operators
-        rejects('{$project: {' +
-          'field: {"$testing": "testing"},' +
-          '}}');
-      });
-      it('accepts nested field', () => {
-        accepts('{$project: {' +
-          '"field.nested": "$new.field.name",' +
-          '}}');
-      });
-      it('accepts nested field without quotes', () => {
-        accepts('{$project: {' +
-          'field.nested: {"$literal": "testing"},' +
-          '}}');
-      });
-      it('accepts fields with whitespace', () => {
-        accepts('{$project: {' +
-          '"    fie   ld.nm   ested    ": "$new.field.name",' +
-          '}}');
-      });
-      it('accepts backslashes', () => {
-        accepts('{$project: {' +
-          '"field\?": "$new.field.name",' +
-          '}}');
-      });
-      it('rejects empty doc', () => {
-        rejects('{$project: {}}');
-      });
-      it('rejects both excluding and including fields', () => {
-        rejects('{$project: {field: true, field2: false}}');
-      });
-      it('accepts excluding id and including other field', () =>{
-        accepts('{$project: {field: true, _id: false}}');
-      });
-      it('accepts a cond exclude', () => {
-        accepts('{\n' +
-          '      $project: {\n' +
-          '         title: 1,\n' +
-          '         "author.first": 1,\n' +
-          '         "author.last" : 1,\n' +
-          '         "author.middle": {\n' +
-          '            $cond: {\n' +
-          '               if: { $eq: [ "", "$author.middle" ] },\n' +
-          '               then: "$$REMOVE",\n' +
-          '               else: "$author.middle"\n' +
-          '            }\n' +
-          '         }\n' +
-          '      }\n' +
-          '   }');
+
+      describe('$facet', () => {
+        it('rejects empty object', () => {
+          rejects('{$facet: {}}');
+        });
+        it('rejects a non-array for stage', () => {
+          rejects('{$facet: {' +
+            'output: {test: 1}' +
+            '}}');
+        });
+        it('rejects an empty pipeline', () => {
+          rejects('{$facet: {' +
+            'output: []' +
+            '}}');
+        });
+        it('accepts a pipeline', () => {
+          accepts('{$facet: {' +
+            '    "categorizedByTags": [' +
+            '        { $unwind: "$tags" },' +
+            '        { $sortByCount: "$tags" }' +
+            '    ],' +
+            '    "categorizedByPrice": [' +
+            '        { $match: { price: { $exists: 1 } } },' +
+            '        {' +
+            '          $bucket: {' +
+            '            groupBy: "$price",' +
+            '            boundaries: [  0, 150, 200, 300, 400 ],' +
+            '            default: "Other",' +
+            '            output: {' +
+            '              "count": { $sum: 1 },' +
+            '              "titles": { $push: "$title" }' +
+            '            }' +
+            '          }' +
+            '        }' +
+            '    ],' +
+            '    "categorizedByYears(Auto)": [' +
+            '        {' +
+            '          $bucketAuto: {' +
+            '            groupBy: "$year",' +
+            '            buckets: 4' +
+            '          }' +
+            '        }' +
+            '    ]' +
+            '}}');
+        });
       });
     });
 
-    describe('$facet', () => {
-      it('rejects empty object', () => {
-        rejects('{$facet: {}}');
+    describe('Key syntax', () => {
+      describe('field', () => {
+        it('rejects fields starting with $', () => {
+          rejects('{$addFields: {' +
+            '   $field1: "value1",' +
+            '}}');
+          rejects('{$addFields: {' +
+            '   \'$field1\': "value1",' +
+            '}}');
+          rejects('{$addFields: {' +
+            '   "$field1": "value1",' +
+            '}}');
+        });
+        it('rejects fields starting with .', () => {
+          rejects('{$addFields: {' +
+            '   .field1: "value1",' +
+            '}}');
+          rejects('{$addFields: {' +
+            '   \'.field1\': "value1",' +
+            '}}');
+          rejects('{$addFields: {' +
+            '   ".field1": "value1",' +
+            '}}');
+        });
+        it('accepts a field with $ or . later on in quotes', () => {
+          accepts('{$addFields: {' +
+            '   \'t.fiel$d1\': "value1",' +
+            '}}');
+          accepts('{$addFields: {' +
+            '   "t.field$1": "value1",' +
+            '}}');
+        });
+        it('rejects a fieldname with space', () => {
+          rejects('{' +
+            '   addFields: {field name: 1' +
+            '}}');
+        });
+        it('rejects a numerical fieldname', () => {
+          rejects('{' +
+            '   addFields: {11: 1' +
+            '}}');
+        });
+        it('accepts a fieldname with space and quotes', () => {
+          accepts('{$addFields: {' +
+            '   "fiel d1": "value1"' +
+            '}}');
+        });
+        it('accepts a fieldname with escaped characters', () => {
+          accepts('{$addFields: {' +
+            '   "\tfiel d\r1": "value1"' +
+            '}}');
+        });
+        it('accepts a nested field name', () => {
+          accepts('{$addFields: {' +
+            '   "name.name2": "value1"' +
+            '}}');
+        });
+        it('accepts an escaped double quote', () => {
+          accepts('{$addFields: {' +
+            '   "fiel\\"d1": "value1"' +
+            '}}');
+        });
+        it('accepts an escaped single quote', () => {
+          accepts('{$addFields: {' +
+            "   'fiel\\'d1': 'value1'" +
+            '}}');
+        });
+        it('accepts an double quote within single quotes', () => {
+          accepts('{$addFields: {' +
+            '   "fiel\'d1": "value1"' +
+            '}}');
+        });
+        it('accepts an single quote within double quotes', () => {
+          accepts('{$addFields: {' +
+            '   \'fiel"d1\': "value1"' +
+            '}}');
+        });
+        it('accepts unicode', () => {
+          accepts('{$addFields: {' +
+            '   "fiel☂d1": "value1"' +
+            '}}');
+        });
       });
-      it('rejects a non-array for stage', () => {
-        rejects('{$facet: {' +
-          'output: {test: 1}' +
-          '}}');
+      describe('object', () => {
+        it('accepts an object', () => {
+          accepts('{$lookup: {' +
+            'from: "fromColl", localField: "inputField",' +
+            'foreignField: "fromField", as: "outArray",' +
+            'let: { test: "value" }' +
+            '}}'
+          );
+        });
+        it('rejects any operators', () => {
+          rejects('{$lookup: {' +
+            'from: "fromColl", localField: "inputField",' +
+            'foreignField: "fromField", as: "outArray",' +
+            'let: { $abs: 1 }' +
+            '}}'
+          );
+        });
+        it('rejects an array', () => {
+          rejects('{$lookup: {' +
+            'from: "fromColl", localField: "inputField",' +
+            'foreignField: "fromField", as: "outArray",' +
+            'let: [1,2]' +
+            '}}'
+          );
+        });
+        it('rejects a constant', () => {
+          rejects('{$lookup: {' +
+            'from: "fromColl", localField: "inputField",' +
+            'foreignField: "fromField", as: "outArray",' +
+            'let: 1' +
+            '}}'
+          );
+        });
       });
-      it('rejects an empty pipeline', () => {
-        rejects('{$facet: {' +
-          'output: []' +
-          '}}');
-      });
-      it('accepts a pipeline', () => {
-        accepts('{$facet: {' +
-          '    "categorizedByTags": [' +
-          '        { $unwind: "$tags" },' +
-          '        { $sortByCount: "$tags" }' +
-          '    ],' +
-          '    "categorizedByPrice": [' +
-          '        { $match: { price: { $exists: 1 } } },' +
-          '        {' +
-          '          $bucket: {' +
-          '            groupBy: "$price",' +
-          '            boundaries: [  0, 150, 200, 300, 400 ],' +
-          '            default: "Other",' +
-          '            output: {' +
-          '              "count": { $sum: 1 },' +
-          '              "titles": { $push: "$title" }' +
-          '            }' +
-          '          }' +
-          '        }' +
-          '    ],' +
-          '    "categorizedByYears(Auto)": [' +
-          '        {' +
-          '          $bucketAuto: {' +
-          '            groupBy: "$year",' +
-          '            buckets: 4' +
-          '          }' +
-          '        }' +
-          '    ]' +
-          '}}');
-      });
-    });
-  });
-
-  describe('Key syntax', () => {
-    describe('field', () => {
-      it('rejects fields starting with $', () => {
-        rejects('{$addFields: {' +
-          '   $field1: "value1",' +
-          '}}');
-        rejects('{$addFields: {' +
-          '   \'$field1\': "value1",' +
-          '}}');
-        rejects('{$addFields: {' +
-          '   "$field1": "value1",' +
-          '}}');
-      });
-      it('rejects fields starting with .', () => {
-        rejects('{$addFields: {' +
-          '   .field1: "value1",' +
-          '}}');
-        rejects('{$addFields: {' +
-          '   \'.field1\': "value1",' +
-          '}}');
-        rejects('{$addFields: {' +
-          '   ".field1": "value1",' +
-          '}}');
-      });
-      it('accepts a field with $ or . later on in quotes', () => {
-        accepts('{$addFields: {' +
-          '   \'t.fiel$d1\': "value1",' +
-          '}}');
-        accepts('{$addFields: {' +
-          '   "t.field$1": "value1",' +
-          '}}');
-      });
-      it('rejects a fieldname with space', () => {
-        rejects('{' +
-          '   addFields: {field name: 1' +
-          '}}');
-      });
-      it('rejects a numerical fieldname', () => {
-        rejects('{' +
-          '   addFields: {11: 1' +
-          '}}');
-      });
-      it('accepts a fieldname with space and quotes', () => {
-        accepts('{$addFields: {' +
-          '   "fiel d1": "value1"' +
-          '}}');
-      });
-      it('accepts a fieldname with escaped characters', () => {
-        accepts('{$addFields: {' +
-          '   "\tfiel d\r1": "value1"' +
-          '}}');
-      });
-      it('accepts a nested field name', () => {
-        accepts('{$addFields: {' +
-          '   "name.name2": "value1"' +
-          '}}');
-      });
-      it('accepts an escaped double quote', () => {
-        accepts('{$addFields: {' +
-          '   "fiel\\"d1": "value1"' +
-          '}}');
-      });
-      it('accepts an escaped single quote', () => {
-        accepts('{$addFields: {' +
-          "   'fiel\\'d1': 'value1'" +
-          '}}');
-      });
-      it('accepts an double quote within single quotes', () => {
-        accepts('{$addFields: {' +
-          '   "fiel\'d1": "value1"' +
-          '}}');
-      });
-      it('accepts an single quote within double quotes', () => {
-        accepts('{$addFields: {' +
-          '   \'fiel"d1\': "value1"' +
-          '}}');
-      });
-      it('accepts unicode', () => {
-        accepts('{$addFields: {' +
-          '   "fiel☂d1": "value1"' +
-          '}}');
-      });
-    });
-    describe('object', () => {
-      it('accepts an object', () => {
-        accepts('{$lookup: {' +
-          'from: "fromColl", localField: "inputField",' +
-          'foreignField: "fromField", as: "outArray",' +
-          'let: { test: "value" }' +
-          '}}'
-        );
-      });
-      it('rejects any operators', () => {
-        rejects('{$lookup: {' +
-          'from: "fromColl", localField: "inputField",' +
-          'foreignField: "fromField", as: "outArray",' +
-          'let: { $abs: 1 }' +
-          '}}'
-        );
-      });
-      it('rejects an array', () => {
-        rejects('{$lookup: {' +
-          'from: "fromColl", localField: "inputField",' +
-          'foreignField: "fromField", as: "outArray",' +
-          'let: [1,2]' +
-          '}}'
-        );
-      });
-      it('rejects a constant', () => {
-        rejects('{$lookup: {' +
-          'from: "fromColl", localField: "inputField",' +
-          'foreignField: "fromField", as: "outArray",' +
-          'let: 1' +
-          '}}'
-        );
-      });
-    });
-    describe('query_expr', () => {
-      it('accepts all operators', () => {
-        accepts('{' +
-          '$match: {' +
+      describe('query_expr', () => {
+        it('accepts all operators', () => {
+          accepts('{' +
+            '$match: {' +
             'a: {$eq: 1}, b: {$gt: 1}, c: {$gte: 1}, d: {$in: 1}, e: {$lt: 1}, f: {$lte: 1}, g: {$ne: 1}, f: {$nin: 1},' +
             'g: {$and: 1}, h: {$or: 1}, i: {$not: 1}, j: {$nor: 1},' +
             'k: {$exists: 1}, l: {$type: 1},' +
@@ -1335,306 +1370,306 @@ describe('#accepts', () => {
             'z: {$bitsAllClear: 1}, a1: {$bitsAllSet: 1}, b1: {$bitsAnyClear: 1}, c1: {$bitsAnySet: 1},' +
             'd1: {$comment: 1},' +
             'e1: {$elemMatch: 1}, f1: {$meta: 1}, g1: {$slice: 1},' +
-          '}}');
-      });
-      it('accepts $text search', () => {
-        accepts('{' +
-        '$match: {' +
-          '$text:' +
+            '}}');
+        });
+        it('accepts $text search', () => {
+          accepts('{' +
+            '$match: {' +
+            '$text:' +
             '{' +
-              '$search: "string",' +
-              '$language: "en",' +
-              '$caseSensitive: true,' +
-              '$diacriticSensitive: false' +
+            '$search: "string",' +
+            '$language: "en",' +
+            '$caseSensitive: true,' +
+            '$diacriticSensitive: false' +
             '}' +
-          '}' +
-        '}');
+            '}' +
+            '}');
+        });
+        it('accepts one op with quotes', () => {
+          accepts('{ $match: { x: {"$lte": 1} } }');
+        });
+        it('accepts $match $in with regex', () => {
+          accepts('{ $match: { x: {"$in": [/abc/]} } }');
+        });
+        it('accepts $match $in $regex with regex', () => {
+          accepts('{ $match: { x: {"$regex": /abc/} } }');
+        });
+        it('accepts $match $expr with $objectToArray', () => {
+          accepts('{ $match: { $expr: { $gt: [{ $size: { $objectToArray: "$tab_map" } }, 0] } } }');
+        });
+        it('accepts all operators with double quotes', () => {
+          accepts('{' +
+            '$match: {' +
+            'a: {"$eq": 1}, b: {"$gt": 1}, c: {"$gte": 1}, d: {"$in": 1}, e: {"$lt": 1}, f: {"$lte": 1}, g: {"$ne": 1}, f: {"$nin": 1},' +
+            'g: {"$and": 1}, h: {"$or": 1}, i: {"$not": 1}, j: {"$nor": 1},' +
+            'k: {"$exists": 1}, l: {"$type": 1},' +
+            'm: {"$expr": 1}, n: {"$jsonSchema": 1}, o: {"$mod": 1}, p: {"$regex": 1}, q: {"$text": 1}, r: {"$where": 1},' +
+            's: {"$geoIntersects": 1}, t: {"$geoWithin": 1},' +
+            'v: {"$nearSphere": 1},' +
+            'u: {"$near": 1},' +
+            'w: {"$all": 1}, x: {"$elemMatch": 1}, y: {"$size": 1},' +
+            'z: {"$bitsAllClear": 1}, a1: {"$bitsAllSet": 1}, b1: {"$bitsAnyClear": 1}, c1: {"$bitsAnySet": 1},' +
+            'd1: {"$comment": 1},' +
+            'e1: {"$elemMatch": 1}, f1: {"$meta": 1}, g1: {"$slice": 1},' +
+            '}}');
+        });
+        it('accepts all operators with single quotes', () => {
+          accepts('{' +
+            '$match: {' +
+            'a: {\'$eq\': 1}, b: {\'$gt\': 1}, c: {\'$gte\': 1}, d: {\'$in\': 1}, e: {\'$lt\': 1}, f: {\'$lte\': 1}, g: {\'$ne\': 1}, f: {\'$nin\': 1},' +
+            'g: {\'$and\': 1}, h: {\'$or\': 1}, i: {\'$not\': 1}, j: {\'$nor\': 1},' +
+            'k: {\'$exists\': 1}, l: {\'$type\': 1},' +
+            'm: {\'$expr\': 1}, n: {\'$jsonSchema\': 1}, o: {\'$mod\': 1}, p: {\'$regex\': 1}, q: {\'$text\': 1}, r: {\'$where\': 1},' +
+            's: {\'$geoIntersects\': 1}, t: {\'$geoWithin\': 1},' +
+            'v: {\'$nearSphere\': 1},' +
+            'u: {\'$near\': 1},' +
+            'w: {\'$all\': 1}, x: {\'$elemMatch\': 1}, y: {\'$size\': 1},' +
+            'z: {\'$bitsAllClear\': 1}, a1: {\'$bitsAllSet\': 1}, b1: {\'$bitsAnyClear\': 1}, c1: {\'$bitsAnySet\': 1},' +
+            'd1: {\'$comment\': 1},' +
+            'e1: {\'$elemMatch\': 1}, f1: {\'$meta\': 1}, g1: {\'$slice\': 1},' +
+            '}}');
+        });
+        it('rejects aggregation operators', () => {
+          rejects('{' +
+            '$match: {' +
+            '$abs: 100' +
+            '}}');
+        });
+        it('rejects nested aggregation operators', () => {
+          rejects('{' +
+            '$match: {' +
+            '   x: {$abs: 100}' +
+            '}}');
+        });
+        it('accepts non-operator fields', () => {
+          accepts('{' +
+            '$match: {x: 100}}');
+        });
       });
-      it('accepts one op with quotes', () => {
-        accepts('{ $match: { x: {"$lte": 1} } }');
-      });
-      it('accepts $match $in with regex', () => {
-        accepts('{ $match: { x: {"$in": [/abc/]} } }');
-      });
-      it('accepts $match $in $regex with regex', () => {
-        accepts('{ $match: { x: {"$regex": /abc/} } }');
-      });
-      it('accepts $match $expr with $objectToArray', () => {
-        accepts('{ $match: { $expr: { $gt: [{ $size: { $objectToArray: "$tab_map" } }, 0] } } }');
-      });
-      it('accepts all operators with double quotes', () => {
-        accepts('{' +
-          '$match: {' +
-          'a: {"$eq": 1}, b: {"$gt": 1}, c: {"$gte": 1}, d: {"$in": 1}, e: {"$lt": 1}, f: {"$lte": 1}, g: {"$ne": 1}, f: {"$nin": 1},' +
-          'g: {"$and": 1}, h: {"$or": 1}, i: {"$not": 1}, j: {"$nor": 1},' +
-          'k: {"$exists": 1}, l: {"$type": 1},' +
-          'm: {"$expr": 1}, n: {"$jsonSchema": 1}, o: {"$mod": 1}, p: {"$regex": 1}, q: {"$text": 1}, r: {"$where": 1},' +
-          's: {"$geoIntersects": 1}, t: {"$geoWithin": 1},' +
-          'v: {"$nearSphere": 1},' +
-          'u: {"$near": 1},' +
-          'w: {"$all": 1}, x: {"$elemMatch": 1}, y: {"$size": 1},' +
-          'z: {"$bitsAllClear": 1}, a1: {"$bitsAllSet": 1}, b1: {"$bitsAnyClear": 1}, c1: {"$bitsAnySet": 1},' +
-          'd1: {"$comment": 1},' +
-          'e1: {"$elemMatch": 1}, f1: {"$meta": 1}, g1: {"$slice": 1},' +
-          '}}');
-      });
-      it('accepts all operators with single quotes', () => {
-        accepts('{' +
-          '$match: {' +
-          'a: {\'$eq\': 1}, b: {\'$gt\': 1}, c: {\'$gte\': 1}, d: {\'$in\': 1}, e: {\'$lt\': 1}, f: {\'$lte\': 1}, g: {\'$ne\': 1}, f: {\'$nin\': 1},' +
-          'g: {\'$and\': 1}, h: {\'$or\': 1}, i: {\'$not\': 1}, j: {\'$nor\': 1},' +
-          'k: {\'$exists\': 1}, l: {\'$type\': 1},' +
-          'm: {\'$expr\': 1}, n: {\'$jsonSchema\': 1}, o: {\'$mod\': 1}, p: {\'$regex\': 1}, q: {\'$text\': 1}, r: {\'$where\': 1},' +
-          's: {\'$geoIntersects\': 1}, t: {\'$geoWithin\': 1},' +
-          'v: {\'$nearSphere\': 1},' +
-          'u: {\'$near\': 1},' +
-          'w: {\'$all\': 1}, x: {\'$elemMatch\': 1}, y: {\'$size\': 1},' +
-          'z: {\'$bitsAllClear\': 1}, a1: {\'$bitsAllSet\': 1}, b1: {\'$bitsAnyClear\': 1}, c1: {\'$bitsAnySet\': 1},' +
-          'd1: {\'$comment\': 1},' +
-          'e1: {\'$elemMatch\': 1}, f1: {\'$meta\': 1}, g1: {\'$slice\': 1},' +
-          '}}');
-      });
-      it('rejects aggregation operators', () => {
-        rejects('{' +
-          '$match: {' +
-              '$abs: 100' +
-          '}}');
-      });
-      it('rejects nested aggregation operators', () => {
-        rejects('{' +
-          '$match: {' +
-          '   x: {$abs: 100}' +
-          '}}');
-      });
-      it('accepts non-operator fields', () => {
-        accepts('{' +
-          '$match: {x: 100}}');
+      describe('agg_expr', () => {
+        it('accepts all operators without quotes part 1', () => {
+          accepts('{$addFields: {' +
+            '   a2: {$abs: 1}, a3: {$cond: 1}, a4: {$gt: 1}, a5: {$gte: 1}, a6: {$lt: 1}, a7: {$lte: 1}, a8: {$in: 1},' +
+            '   a: {$addToSet: 1}, q: {$and: 1}, w: {$avg: 1}, e: {$eq: 1}, r: {$first: 1},' +
+            '   t: {$gte: 1}, y: {$gt: 1}, u: {$lte: 1}, i: {$lt: 1}, o: {$in: 1},' +
+            '   p: {$last: 1}, a: {$meta: 1}, s: {$max: 1}, d: {$min: 1}, f: {$mod: 1},' +
+            '   g: {$ne: 1}, h: {$not: 1}, j: {$or: 1}, j2: {$push: 1}, k: {$size: 1},' +
+            '   l: {$slice: 1}, z: {$stdDevPop: 1}, x: {$stdDevSamp: 1}, c: {$sum: 1},' +
+            '   v: {$type: 1}, v2: {$abs: 1}, b: {$add: 1}, n: {$allElementsTrue: 1}, ' +
+            '   m: {$anyElementTrue: 1}, m1: {$arrayElemAt: 1}, 11: {$arrayToObject: 1},' +
+            '   2: {$ceil: 1}, 3: {$cmp: 1}, 4: {$concatArrays: 1}, 5: {$concat: 1},' +
+            '   6: {$dateFromParts: 1}, 7: {$dateFromString: 1}, 8: {$dateToString: 1},' +
+            '   9: {$dateToParts: 1}, 0: {$dayOfMonth: 1}, ' +
+            '}}');
+        });
+        it('accepts all operators part 1 with double quotes', () => {
+          accepts('{$addFields: {' +
+            '   a2: {"$abs": 1}, a3: {"$cond": 1}, a4: {"$gt": 1}, a5: {"$gte": 1}, a6: {"$lt": 1}, a7: {"$lte": 1}, a8: {"$in": 1},' +
+            '   a: {"$addToSet": 1}, q: {"$and": 1}, w: {"$avg": 1}, e: {"$eq": 1}, r: {"$first": 1},' +
+            '   t: {"$gte": 1}, y: {"$gt": 1}, u: {"$lte": 1}, i: {"$lt": 1}, o: {"$in": 1},' +
+            '   p: {"$last": 1}, a: {"$meta": 1}, s: {"$max": 1}, d: {"$min": 1}, f: {"$mod": 1},' +
+            '   g: {"$ne": 1}, h: {"$not": 1}, j: {"$or": 1}, j2: {"$push": 1}, k: {"$size": 1},' +
+            '   l: {"$slice": 1}, z: {"$stdDevPop": 1}, x: {"$stdDevSamp": 1}, c: {"$sum": 1},' +
+            '   v: {"$type": 1}, v2: {"$abs": 1}, b: {"$add": 1}, n: {"$allElementsTrue": 1}, ' +
+            '   m: {"$anyElementTrue": 1}, m1: {"$arrayElemAt": 1}, 11: {"$arrayToObject": 1},' +
+            '   2: {"$ceil": 1}, 3: {"$cmp": 1}, 4: {"$concatArrays": 1}, 5: {"$concat": 1},' +
+            '   6: {"$dateFromParts": 1}, 7: {"$dateFromString": 1}, 8: {"$dateToString": 1},' +
+            '   9: {"$dateToParts": 1}, 0: {"$dayOfMonth": 1}, ' +
+            '}}');
+        });
+        it('accepts all operators part 1 with single quotes', () => {
+          accepts('{$addFields: {' +
+            '   a2: {\'$abs\': 1}, a3: {\'$cond\': 1}, a4: {\'$gt\': 1}, a5: {\'$gte\': 1}, a6: {\'$lt\': 1}, a7: {\'$lte\': 1}, a8: {\'$in\': 1},' +
+            '   a: {\'$addToSet\': 1}, q: {\'$and\': 1}, w: {\'$avg\': 1}, e: {\'$eq\': 1}, r: {\'$first\': 1},' +
+            '   t: {\'$gte\': 1}, y: {\'$gt\': 1}, u: {\'$lte\': 1}, i: {\'$lt\': 1}, o: {\'$in\': 1},' +
+            '   p: {\'$last\': 1}, a: {\'$meta\': 1}, s: {\'$max\': 1}, d: {\'$min\': 1}, f: {\'$mod\': 1},' +
+            '   g: {\'$ne\': 1}, h: {\'$not\': 1}, j: {\'$or\': 1}, j2: {\'$push\': 1}, k: {\'$size\': 1},' +
+            '   l: {\'$slice\': 1}, z: {\'$stdDevPop\': 1}, x: {\'$stdDevSamp\': 1}, c: {\'$sum\': 1},' +
+            '   v: {\'$type\': 1}, v2: {\'$abs\': 1}, b: {\'$add\': 1}, n: {\'$allElementsTrue\': 1}, ' +
+            '   m: {\'$anyElementTrue\': 1}, m1: {\'$arrayElemAt\': 1}, 11: {\'$arrayToObject\': 1},' +
+            '   2: {\'$ceil\': 1}, 3: {\'$cmp\': 1}, 4: {\'$concatArrays\': 1}, 5: {\'$concat\': 1},' +
+            '   6: {\'$dateFromParts\': 1}, 7: {\'$dateFromString\': 1}, 8: {\'$dateToString\': 1},' +
+            '   9: {\'$dateToParts\': 1}, 0: {\'$dayOfMonth\': 1}, ' +
+            '}}');
+        });
+        it('accepts all operators part 2', () => {
+          accepts('{$addFields: {' +
+            '   q: {$dayOfWeek: 1}, w: {$dayOfYear: 1}, e: {$divide: 1}, r: {$exp: 1},' +
+            '   t: {$filter: 1}, y: {$floor: 1}, u: {$hour: 1}, i: {$ifNull: 1}, a1: {$isArray: 1},' +
+            '   o: {$indexOfBytes: 1}, p: {$indexOfArray: 1}, a: {$indexOfCP: 1},' +
+            '   s: {$isoDayOfWeek: 1}, d: {$isoWeek: 1}, f: {$isoWeekYear: 1}, ' +
+            '   g: {$let: 1}, g1: {$literal: 1}, h: {$ln: 1}, j: {$log10: 1}, ' +
+            '   k: {$log: 1}, l: {$map: 1}, z: {$mergeObjects: 1}, z1: {$millisecond: 1},' +
+            '   x: {$minute: 1}, c: {$month: 1}, v: {$multiply: 1}, b: {$objectToArray: 1}, ' +
+            '   n: {$pow: 1}, m: {$range: 1}, m2: {$reduce: 1}, 1: {$reverseArray: 1},' +
+            '   2: {$second: 1}, 3: {$setDifference: 1}, 4: {$setEquals: 1}, 5: {$setIntersection: 1},' +
+            '   6: {$setIsSubset: 1}, 7: {$setUnion: 1}, 8: {$split: 1}, 9: {$sqrt: 1},' +
+            '   0: {$strcasecmp: 1}, 11: {$strLenBytes: 1}, 22: {$strLenCP: 1},' +
+            '   33: {$substrBytes: 1}, 44: {$substrCP: 1}, 55: {$substr: 1}, ' +
+            '   77: {$subtract: 1}, 88: {$switch: 1}, 99: {$toLower: 1}, ' +
+            '   aa: {$toUpper: 1}, ss: {$trunc: 1}, dd: {$week: 1}, ff: {$year: 1},' +
+            '   gg: {$zip: 1} ' +
+            '}}');
+        });
+        it('accepts all operators part 2 with double quotes', () => {
+          accepts('{$addFields: {' +
+            '   q: {"$dayOfWeek": 1}, w: {"$dayOfYear": 1}, e: {"$divide": 1}, r: {"$exp": 1},' +
+            '   t: {"$filter": 1}, y: {"$floor": 1}, u: {"$hour": 1}, i: {"$ifNull": 1}, a1: {"$isArray": 1},' +
+            '   o: {"$indexOfBytes": 1}, p: {"$indexOfArray": 1}, a: {"$indexOfCP": 1},' +
+            '   s: {"$isoDayOfWeek": 1}, d: {"$isoWeek": 1}, f: {"$isoWeekYear": 1}, ' +
+            '   g: {"$let": 1}, g1: {"$literal": 1}, h: {"$ln": 1}, j: {"$log10": 1}, ' +
+            '   k: {"$log": 1}, l: {"$map": 1}, z: {"$mergeObjects": 1}, z1: {"$millisecond": 1},' +
+            '   x: {"$minute": 1}, c: {"$month": 1}, v: {"$multiply": 1}, b: {"$objectToArray": 1}, ' +
+            '   n: {"$pow": 1}, m: {"$range": 1}, m2: {"$reduce": 1}, 1: {"$reverseArray": 1},' +
+            '   2: {"$second": 1}, 3: {"$setDifference": 1}, 4: {"$setEquals": 1}, 5: {"$setIntersection": 1},' +
+            '   6: {"$setIsSubset": 1}, 7: {"$setUnion": 1}, 8: {"$split": 1}, 9: {"$sqrt": 1},' +
+            '   0: {"$strcasecmp": 1}, 11: {"$strLenBytes": 1}, 22: {"$strLenCP": 1},' +
+            '   33: {"$substrBytes": 1}, 44: {"$substrCP": 1}, 55: {"$substr": 1}, ' +
+            '   77: {"$subtract": 1}, 88: {"$switch": 1}, 99: {"$toLower": 1}, ' +
+            '   aa: {"$toUpper": 1}, ss: {"$trunc": 1}, dd: {"$week": 1}, ff: {"$year": 1},' +
+            '   gg: {"$zip": 1} ' +
+            '}}');
+        });
+        it('accepts all operators part 2 with single quotes', () => {
+          accepts('{$addFields: {' +
+            '   q: {\'$dayOfWeek\': 1}, w: {\'$dayOfYear\': 1}, e: {\'$divide\': 1}, r: {\'$exp\': 1},' +
+            '   t: {\'$filter\': 1}, y: {\'$floor\': 1}, u: {\'$hour\': 1}, i: {\'$ifNull\': 1}, a1: {\'$isArray\': 1},' +
+            '   o: {\'$indexOfBytes\': 1}, p: {\'$indexOfArray\': 1}, a: {\'$indexOfCP\': 1},' +
+            '   s: {\'$isoDayOfWeek\': 1}, d: {\'$isoWeek\': 1}, f: {\'$isoWeekYear\': 1}, ' +
+            '   g: {\'$let\': 1}, g1: {\'$literal\': 1}, h: {\'$ln\': 1}, j: {\'$log10\': 1}, ' +
+            '   k: {\'$log\': 1}, l: {\'$map\': 1}, z: {\'$mergeObjects\': 1}, z1: {\'$millisecond\': 1},' +
+            '   x: {\'$minute\': 1}, c: {\'$month\': 1}, v: {\'$multiply\': 1}, b: {\'$objectToArray\': 1}, ' +
+            '   n: {\'$pow\': 1}, m: {\'$range\': 1}, m2: {\'$reduce\': 1}, 1: {\'$reverseArray\': 1},' +
+            '   2: {\'$second\': 1}, 3: {\'$setDifference\': 1}, 4: {\'$setEquals\': 1}, 5: {\'$setIntersection\': 1},' +
+            '   6: {\'$setIsSubset\': 1}, 7: {\'$setUnion\': 1}, 8: {\'$split\': 1}, 9: {\'$sqrt\': 1},' +
+            '   0: {\'$strcasecmp\': 1}, 11: {\'$strLenBytes\': 1}, 22: {\'$strLenCP\': 1},' +
+            '   33: {\'$substrBytes\': 1}, 44: {\'$substrCP\': 1}, 55: {\'$substr\': 1}, ' +
+            '   77: {\'$subtract\': 1}, 88: {\'$switch\': 1}, 99: {\'$toLower\': 1}, ' +
+            '   aa: {\'$toUpper\': 1}, ss: {\'$trunc\': 1}, dd: {\'$week\': 1}, ff: {\'$year\': 1},' +
+            '   gg: {\'$zip\': 1} ' +
+            '}}');
+        });
+        it('rejects query operators', () => {
+          rejects('{' +
+            '$addFields: {' +
+            '   x: {$regex: 100}' +
+            '}}');
+          rejects('{' +
+            '$addFields: {' +
+            '   x: {"$regex": 100}' +
+            '}}');
+          rejects('{' +
+            '$addFields: {' +
+            '   x: {\'$regex\': 100}' +
+            '}}');
+        });
+        it('accepts accumulators', () => {
+          accepts('{' +
+            '$addFields: {' +
+            '   x: {$sum: 100}' +
+            '}}');
+          accepts('{' +
+            '$addFields: {' +
+            '   x: {"$sum": 100}' +
+            '}}');
+          accepts('{' +
+            '$addFields: {' +
+            '   x: {\'$sum\': 100}' +
+            '}}');
+        });
+        it('rejects nested query operators', () => {
+          rejects('{' +
+            '$addFields: {' +
+            '   x: { y: {$regex: 100}}' +
+            '}}');
+        });
+        it('accepts non-operator fields', () => {
+          accepts('{$addFields: {x: 100}}');
+        });
+        it('rejects arbitrary $', () => {
+          rejects('{' +
+            '$addFields: {' +
+            '   x: {$otherfield: 100}' +
+            '}}');
+          rejects('{' +
+            '$addFields: {' +
+            '   x: {"$otherfield": 100}' +
+            '}}');
+          rejects('{' +
+            '$addFields: {' +
+            '   x: {\'$otherfield\': 100}' +
+            '}}');
+        });
       });
     });
-    describe('agg_expr', () => {
-      it('accepts all operators without quotes part 1', () => {
-        accepts('{$addFields: {' +
-          '   a2: {$abs: 1}, a3: {$cond: 1}, a4: {$gt: 1}, a5: {$gte: 1}, a6: {$lt: 1}, a7: {$lte: 1}, a8: {$in: 1},' +
-          '   a: {$addToSet: 1}, q: {$and: 1}, w: {$avg: 1}, e: {$eq: 1}, r: {$first: 1},' +
-          '   t: {$gte: 1}, y: {$gt: 1}, u: {$lte: 1}, i: {$lt: 1}, o: {$in: 1},' +
-          '   p: {$last: 1}, a: {$meta: 1}, s: {$max: 1}, d: {$min: 1}, f: {$mod: 1},' +
-          '   g: {$ne: 1}, h: {$not: 1}, j: {$or: 1}, j2: {$push: 1}, k: {$size: 1},' +
-          '   l: {$slice: 1}, z: {$stdDevPop: 1}, x: {$stdDevSamp: 1}, c: {$sum: 1},' +
-          '   v: {$type: 1}, v2: {$abs: 1}, b: {$add: 1}, n: {$allElementsTrue: 1}, ' +
-          '   m: {$anyElementTrue: 1}, m1: {$arrayElemAt: 1}, 11: {$arrayToObject: 1},' +
-          '   2: {$ceil: 1}, 3: {$cmp: 1}, 4: {$concatArrays: 1}, 5: {$concat: 1},' +
-          '   6: {$dateFromParts: 1}, 7: {$dateFromString: 1}, 8: {$dateToString: 1},' +
-          '   9: {$dateToParts: 1}, 0: {$dayOfMonth: 1}, ' +
-          '}}');
-      });
-      it('accepts all operators part 1 with double quotes', () => {
-        accepts('{$addFields: {' +
-          '   a2: {"$abs": 1}, a3: {"$cond": 1}, a4: {"$gt": 1}, a5: {"$gte": 1}, a6: {"$lt": 1}, a7: {"$lte": 1}, a8: {"$in": 1},' +
-          '   a: {"$addToSet": 1}, q: {"$and": 1}, w: {"$avg": 1}, e: {"$eq": 1}, r: {"$first": 1},' +
-          '   t: {"$gte": 1}, y: {"$gt": 1}, u: {"$lte": 1}, i: {"$lt": 1}, o: {"$in": 1},' +
-          '   p: {"$last": 1}, a: {"$meta": 1}, s: {"$max": 1}, d: {"$min": 1}, f: {"$mod": 1},' +
-          '   g: {"$ne": 1}, h: {"$not": 1}, j: {"$or": 1}, j2: {"$push": 1}, k: {"$size": 1},' +
-          '   l: {"$slice": 1}, z: {"$stdDevPop": 1}, x: {"$stdDevSamp": 1}, c: {"$sum": 1},' +
-          '   v: {"$type": 1}, v2: {"$abs": 1}, b: {"$add": 1}, n: {"$allElementsTrue": 1}, ' +
-          '   m: {"$anyElementTrue": 1}, m1: {"$arrayElemAt": 1}, 11: {"$arrayToObject": 1},' +
-          '   2: {"$ceil": 1}, 3: {"$cmp": 1}, 4: {"$concatArrays": 1}, 5: {"$concat": 1},' +
-          '   6: {"$dateFromParts": 1}, 7: {"$dateFromString": 1}, 8: {"$dateToString": 1},' +
-          '   9: {"$dateToParts": 1}, 0: {"$dayOfMonth": 1}, ' +
-          '}}');
-      });
-      it('accepts all operators part 1 with single quotes', () => {
-        accepts('{$addFields: {' +
-          '   a2: {\'$abs\': 1}, a3: {\'$cond\': 1}, a4: {\'$gt\': 1}, a5: {\'$gte\': 1}, a6: {\'$lt\': 1}, a7: {\'$lte\': 1}, a8: {\'$in\': 1},' +
-          '   a: {\'$addToSet\': 1}, q: {\'$and\': 1}, w: {\'$avg\': 1}, e: {\'$eq\': 1}, r: {\'$first\': 1},' +
-          '   t: {\'$gte\': 1}, y: {\'$gt\': 1}, u: {\'$lte\': 1}, i: {\'$lt\': 1}, o: {\'$in\': 1},' +
-          '   p: {\'$last\': 1}, a: {\'$meta\': 1}, s: {\'$max\': 1}, d: {\'$min\': 1}, f: {\'$mod\': 1},' +
-          '   g: {\'$ne\': 1}, h: {\'$not\': 1}, j: {\'$or\': 1}, j2: {\'$push\': 1}, k: {\'$size\': 1},' +
-          '   l: {\'$slice\': 1}, z: {\'$stdDevPop\': 1}, x: {\'$stdDevSamp\': 1}, c: {\'$sum\': 1},' +
-          '   v: {\'$type\': 1}, v2: {\'$abs\': 1}, b: {\'$add\': 1}, n: {\'$allElementsTrue\': 1}, ' +
-          '   m: {\'$anyElementTrue\': 1}, m1: {\'$arrayElemAt\': 1}, 11: {\'$arrayToObject\': 1},' +
-          '   2: {\'$ceil\': 1}, 3: {\'$cmp\': 1}, 4: {\'$concatArrays\': 1}, 5: {\'$concat\': 1},' +
-          '   6: {\'$dateFromParts\': 1}, 7: {\'$dateFromString\': 1}, 8: {\'$dateToString\': 1},' +
-          '   9: {\'$dateToParts\': 1}, 0: {\'$dayOfMonth\': 1}, ' +
-          '}}');
-      });
-      it('accepts all operators part 2', () => {
-        accepts('{$addFields: {' +
-          '   q: {$dayOfWeek: 1}, w: {$dayOfYear: 1}, e: {$divide: 1}, r: {$exp: 1},' +
-          '   t: {$filter: 1}, y: {$floor: 1}, u: {$hour: 1}, i: {$ifNull: 1}, a1: {$isArray: 1},' +
-          '   o: {$indexOfBytes: 1}, p: {$indexOfArray: 1}, a: {$indexOfCP: 1},' +
-          '   s: {$isoDayOfWeek: 1}, d: {$isoWeek: 1}, f: {$isoWeekYear: 1}, ' +
-          '   g: {$let: 1}, g1: {$literal: 1}, h: {$ln: 1}, j: {$log10: 1}, ' +
-          '   k: {$log: 1}, l: {$map: 1}, z: {$mergeObjects: 1}, z1: {$millisecond: 1},' +
-          '   x: {$minute: 1}, c: {$month: 1}, v: {$multiply: 1}, b: {$objectToArray: 1}, ' +
-          '   n: {$pow: 1}, m: {$range: 1}, m2: {$reduce: 1}, 1: {$reverseArray: 1},' +
-          '   2: {$second: 1}, 3: {$setDifference: 1}, 4: {$setEquals: 1}, 5: {$setIntersection: 1},' +
-          '   6: {$setIsSubset: 1}, 7: {$setUnion: 1}, 8: {$split: 1}, 9: {$sqrt: 1},' +
-          '   0: {$strcasecmp: 1}, 11: {$strLenBytes: 1}, 22: {$strLenCP: 1},' +
-          '   33: {$substrBytes: 1}, 44: {$substrCP: 1}, 55: {$substr: 1}, ' +
-          '   77: {$subtract: 1}, 88: {$switch: 1}, 99: {$toLower: 1}, ' +
-          '   aa: {$toUpper: 1}, ss: {$trunc: 1}, dd: {$week: 1}, ff: {$year: 1},' +
-          '   gg: {$zip: 1} ' +
-          '}}');
-      });
-      it('accepts all operators part 2 with double quotes', () => {
-        accepts('{$addFields: {' +
-          '   q: {"$dayOfWeek": 1}, w: {"$dayOfYear": 1}, e: {"$divide": 1}, r: {"$exp": 1},' +
-          '   t: {"$filter": 1}, y: {"$floor": 1}, u: {"$hour": 1}, i: {"$ifNull": 1}, a1: {"$isArray": 1},' +
-          '   o: {"$indexOfBytes": 1}, p: {"$indexOfArray": 1}, a: {"$indexOfCP": 1},' +
-          '   s: {"$isoDayOfWeek": 1}, d: {"$isoWeek": 1}, f: {"$isoWeekYear": 1}, ' +
-          '   g: {"$let": 1}, g1: {"$literal": 1}, h: {"$ln": 1}, j: {"$log10": 1}, ' +
-          '   k: {"$log": 1}, l: {"$map": 1}, z: {"$mergeObjects": 1}, z1: {"$millisecond": 1},' +
-          '   x: {"$minute": 1}, c: {"$month": 1}, v: {"$multiply": 1}, b: {"$objectToArray": 1}, ' +
-          '   n: {"$pow": 1}, m: {"$range": 1}, m2: {"$reduce": 1}, 1: {"$reverseArray": 1},' +
-          '   2: {"$second": 1}, 3: {"$setDifference": 1}, 4: {"$setEquals": 1}, 5: {"$setIntersection": 1},' +
-          '   6: {"$setIsSubset": 1}, 7: {"$setUnion": 1}, 8: {"$split": 1}, 9: {"$sqrt": 1},' +
-          '   0: {"$strcasecmp": 1}, 11: {"$strLenBytes": 1}, 22: {"$strLenCP": 1},' +
-          '   33: {"$substrBytes": 1}, 44: {"$substrCP": 1}, 55: {"$substr": 1}, ' +
-          '   77: {"$subtract": 1}, 88: {"$switch": 1}, 99: {"$toLower": 1}, ' +
-          '   aa: {"$toUpper": 1}, ss: {"$trunc": 1}, dd: {"$week": 1}, ff: {"$year": 1},' +
-          '   gg: {"$zip": 1} ' +
-          '}}');
-      });
-      it('accepts all operators part 2 with single quotes', () => {
-        accepts('{$addFields: {' +
-          '   q: {\'$dayOfWeek\': 1}, w: {\'$dayOfYear\': 1}, e: {\'$divide\': 1}, r: {\'$exp\': 1},' +
-          '   t: {\'$filter\': 1}, y: {\'$floor\': 1}, u: {\'$hour\': 1}, i: {\'$ifNull\': 1}, a1: {\'$isArray\': 1},' +
-          '   o: {\'$indexOfBytes\': 1}, p: {\'$indexOfArray\': 1}, a: {\'$indexOfCP\': 1},' +
-          '   s: {\'$isoDayOfWeek\': 1}, d: {\'$isoWeek\': 1}, f: {\'$isoWeekYear\': 1}, ' +
-          '   g: {\'$let\': 1}, g1: {\'$literal\': 1}, h: {\'$ln\': 1}, j: {\'$log10\': 1}, ' +
-          '   k: {\'$log\': 1}, l: {\'$map\': 1}, z: {\'$mergeObjects\': 1}, z1: {\'$millisecond\': 1},' +
-          '   x: {\'$minute\': 1}, c: {\'$month\': 1}, v: {\'$multiply\': 1}, b: {\'$objectToArray\': 1}, ' +
-          '   n: {\'$pow\': 1}, m: {\'$range\': 1}, m2: {\'$reduce\': 1}, 1: {\'$reverseArray\': 1},' +
-          '   2: {\'$second\': 1}, 3: {\'$setDifference\': 1}, 4: {\'$setEquals\': 1}, 5: {\'$setIntersection\': 1},' +
-          '   6: {\'$setIsSubset\': 1}, 7: {\'$setUnion\': 1}, 8: {\'$split\': 1}, 9: {\'$sqrt\': 1},' +
-          '   0: {\'$strcasecmp\': 1}, 11: {\'$strLenBytes\': 1}, 22: {\'$strLenCP\': 1},' +
-          '   33: {\'$substrBytes\': 1}, 44: {\'$substrCP\': 1}, 55: {\'$substr\': 1}, ' +
-          '   77: {\'$subtract\': 1}, 88: {\'$switch\': 1}, 99: {\'$toLower\': 1}, ' +
-          '   aa: {\'$toUpper\': 1}, ss: {\'$trunc\': 1}, dd: {\'$week\': 1}, ff: {\'$year\': 1},' +
-          '   gg: {\'$zip\': 1} ' +
-          '}}');
-      });
-      it('rejects query operators', () => {
-        rejects('{' +
-          '$addFields: {' +
-          '   x: {$regex: 100}' +
-          '}}');
-        rejects('{' +
-          '$addFields: {' +
-          '   x: {"$regex": 100}' +
-          '}}');
-        rejects('{' +
-          '$addFields: {' +
-          '   x: {\'$regex\': 100}' +
-          '}}');
-      });
-      it('accepts accumulators', () => {
-        accepts('{' +
-          '$addFields: {' +
-          '   x: {$sum: 100}' +
-          '}}');
-        accepts('{' +
-          '$addFields: {' +
-          '   x: {"$sum": 100}' +
-          '}}');
-        accepts('{' +
-          '$addFields: {' +
-          '   x: {\'$sum\': 100}' +
-          '}}');
-      });
-      it('rejects nested query operators', () => {
-        rejects('{' +
-          '$addFields: {' +
-          '   x: { y: {$regex: 100}}' +
-          '}}');
-      });
-      it('accepts non-operator fields', () => {
-        accepts('{$addFields: {x: 100}}');
-      });
-      it('rejects arbitrary $', () => {
-        rejects('{' +
-        '$addFields: {' +
-        '   x: {$otherfield: 100}' +
-        '}}');
-        rejects('{' +
-          '$addFields: {' +
-          '   x: {"$otherfield": 100}' +
-          '}}');
-        rejects('{' +
-          '$addFields: {' +
-          '   x: {\'$otherfield\': 100}' +
-          '}}');
-      });
-    });
-  });
 
-  describe('Extended JSON Syntax', () => {
-    it('accepts Code', () => {
-      accepts('{ $addFields: { x: Code("xxx") } }');
+    describe('Extended JSON Syntax', () => {
+      it('accepts Code', () => {
+        accepts('{ $addFields: { x: Code("xxx") } }');
+      });
+      it('accepts ObjectId', () => {
+        accepts('{ $addFields: {' +
+          '   x: ObjectId("53c2b570c15c457669f481f7"),' +
+          '   x: ObjectId(\'53c2b570c15c457669f481f7\'),' +
+          '}}');
+      });
+      it('accepts Binary', () => {
+        accepts('{ $addFields: { x: Binary("SGVs\)bG8gV29ybGQ=", "0"), y: 1 } }');
+      });
+      it('accepts DbRef', () => {
+        accepts('{ $addFields: { x: DBRef("name", ObjectId(1)) } }');
+      });
+      it('accepts Timestamp', () => {
+        accepts('{ $addFields: { x: Timestamp(3456789, NumberInt(100)) } }');
+      });
+      it('accepts NumberLong', () => {
+        accepts('{ $addFields: { x: NumberLong("23456789") } }');
+      });
+      it('accepts NumberInt', () => {
+        accepts('{ $addFields: { x: NumberInt(234567890) } }');
+      });
+      it('accepts NumberDecimal', () => {
+        accepts('{ $addFields: { x: NumberDecimal(234567.23456789) } }');
+      });
+      it('accepts MaxKey', () => {
+        accepts('{ $addFields: { x: MaxKey() } }');
+      });
+      it('accepts MinKey', () => {
+        accepts('{ $addFields: { x: MinKey() } }');
+      });
+      it('accepts Date', () => {
+        accepts('{ $addFields: { x: Date(\'1999-01-01\') } }');
+      });
+      it('accepts ISODate', () => {
+        accepts('{ $addFields: { x: ISODate(\'2007-05-25 08:51:27.000\') } }');
+      });
+      it('accepts RegExp', () => {
+        accepts('{ $addFields: { x: RegExp(\'/^[a-z0-9_-]{3,16}$/)\'))) } }');
+      });
+      it('accepts Undefined', () => {
+        accepts('{ $addFields: { x: Undefined() } }');
+      });
     });
-    it('accepts ObjectId', () => {
-      accepts('{ $addFields: {' +
-        '   x: ObjectId("53c2b570c15c457669f481f7"),' +
-        '   x: ObjectId(\'53c2b570c15c457669f481f7\'),' +
-        '}}');
-    });
-    it('accepts Binary', () => {
-      accepts('{ $addFields: { x: Binary("SGVs\)bG8gV29ybGQ=", "0"), y: 1 } }');
-    });
-    it('accepts DbRef', () => {
-      accepts('{ $addFields: { x: DBRef("name", ObjectId(1)) } }');
-    });
-    it('accepts Timestamp', () => {
-      accepts('{ $addFields: { x: Timestamp(3456789, NumberInt(100)) } }');
-    });
-    it('accepts NumberLong', () => {
-      accepts('{ $addFields: { x: NumberLong("23456789") } }');
-    });
-    it('accepts NumberInt', () => {
-      accepts('{ $addFields: { x: NumberInt(234567890) } }');
-    });
-    it('accepts NumberDecimal', () => {
-      accepts('{ $addFields: { x: NumberDecimal(234567.23456789) } }');
-    });
-    it('accepts MaxKey', () => {
-      accepts('{ $addFields: { x: MaxKey() } }');
-    });
-    it('accepts MinKey', () => {
-      accepts('{ $addFields: { x: MinKey() } }');
-    });
-    it('accepts Date', () => {
-      accepts('{ $addFields: { x: Date(\'1999-01-01\') } }');
-    });
-    it('accepts ISODate', () => {
-      accepts('{ $addFields: { x: ISODate(\'2007-05-25 08:51:27.000\') } }');
-    });
-    it('accepts RegExp', () => {
-      accepts('{ $addFields: { x: RegExp(\'/^[a-z0-9_-]{3,16}$/)\'))) } }');
-    });
-    it('accepts Undefined', () => {
-      accepts('{ $addFields: { x: Undefined() } }');
-    });
-  });
 
-  describe('Invalid stage', () => {
-    it('rejects an empty stage', () => {
-      rejects('{}');
-    });
-    it('rejects a non-operator', () => {
-      rejects('{$notanoperator: 1}');
-    });
-    it('rejects a missing $', () => {
-      rejects('{sort: 1}');
-    });
-    it('rejects constants for complex operators', () => {
-      rejects('{$addFields: 1}');
-    });
-    it('rejects a pipeline', () => {
-      rejects('[{$match: {x: 1}}, {$sort: 1}]');
-    });
-    it('rejects text', () => {
-      rejects('a pipeline');
+    describe('Invalid stage', () => {
+      it('rejects an empty stage', () => {
+        rejects('{}');
+      });
+      it('rejects a non-operator', () => {
+        rejects('{$notanoperator: 1}');
+      });
+      it('rejects a missing $', () => {
+        rejects('{sort: 1}');
+      });
+      it('rejects constants for complex operators', () => {
+        rejects('{$addFields: 1}');
+      });
+      it('rejects a pipeline', () => {
+        rejects('[{$match: {x: 1}}, {$sort: 1}]');
+      });
+      it('rejects text', () => {
+        rejects('a pipeline');
+      });
     });
   });
 });
-

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -13,52 +13,54 @@ describe('#parse', () => {
     describe('constants', () => {
       // Constants
       it('$limit accepts a positive integer', () => {
-        accepts({'$limit': 1});
+        accepts({ '$limit': 1 });
       });
       it('$count accepts a string', () => {
-        accepts({'$count': 'id field'});
+        accepts({ '$count': 'id field' });
       });
       it('$skip accepts a positive integer', () => {
-        accepts({'$skip': 10});
+        accepts({ '$skip': 10 });
       });
       it('$out accepts a string', () => {
-        accepts({'$out': 'coll'});
+        accepts({ '$out': 'coll' });
       });
       it('$indexStats accepts an empty document', () => {
-        accepts({'$indexStats': {}});
+        accepts({ '$indexStats': {} });
       });
     });
   });
 
   describe('simple expr', () => {
     it('$sortByCount returns a constant', () => {
-      accepts({'$sortByCount': '$field'});
+      accepts({ '$sortByCount': '$field' });
     });
     it('$sortByCount returns a constant expr', () => {
-      accepts({'$sortByCount': {'$eq': '$testing'}});
+      accepts({ '$sortByCount': { '$eq': '$testing' } });
     });
     it('$sortByCount returns an object expr', () => {
-      accepts({'$sortByCount': {'$eq': {x: '$testing'}}});
+      accepts({ '$sortByCount': { '$eq': { x: '$testing' } } });
     });
     it('$sortByCount returns an array expr', () => {
-      accepts({'$sortByCount': {'$mergeObjects': ['$test', '$test2']}});
+      accepts({ '$sortByCount': { '$mergeObjects': ['$test', '$test2'] } });
     });
     it('$redact returns a sys var', () => {
-      accepts({'$redact': '$$PRUNE'});
-      accepts({'$redact': '$$DESCEND'});
-      accepts({'$redact': '$$KEEP'});
+      accepts({ '$redact': '$$PRUNE' });
+      accepts({ '$redact': '$$DESCEND' });
+      accepts({ '$redact': '$$KEEP' });
     });
     it('$redact returns mixed expr', () => {
       accepts(
-        {'$redact': {
-          '$cond': {
-            if: {
-              '$eq': [ '$level', 5 ]
-            },
-            then: '$$PRUNE',
-            else: '$$DESCEND'
+        {
+          '$redact': {
+            '$cond': {
+              if: {
+                '$eq': ['$level', 5]
+              },
+              then: '$$PRUNE',
+              else: '$$DESCEND'
+            }
           }
-        }});
+        });
     });
     it('$sample a doc with size', () => {
       accepts({ '$sample': { size: 10 } });
@@ -67,16 +69,16 @@ describe('#parse', () => {
       accepts({ '$sample': { 'size': 10 } });
     });
     it('$replaceRoot returns a doc with newRoot', () => {
-      accepts({ '$replaceRoot': { newRoot: {x: 10} } });
+      accepts({ '$replaceRoot': { newRoot: { x: 10 } } });
     });
     it('$replaceRoot returns a doc with empty newRoot', () => {
       accepts({ '$replaceRoot': { newRoot: {} } });
     });
     it('$replaceRoot returns a doc with "newRoot"', () => {
-      accepts({ '$replaceRoot': { 'newRoot': {x: 10} } });
+      accepts({ '$replaceRoot': { 'newRoot': { x: 10 } } });
     });
     it('$replaceRoot returns an agg expr', () => {
-      accepts({ '$replaceRoot': { 'newRoot': {'$abs': 10} } });
+      accepts({ '$replaceRoot': { 'newRoot': { '$abs': 10 } } });
     });
     it('$replaceRoot returns a doc with a string', () => {
       accepts({ '$replaceRoot': { 'newRoot': '$something' } });
@@ -88,249 +90,316 @@ describe('#parse', () => {
       accepts({ '$collStats': {} });
     });
     it('$collStats returns just latencyStats', () => {
-      accepts({ '$collStats': { latencyStats: {histograms: true}}});
+      accepts({ '$collStats': { latencyStats: { histograms: true } } });
     });
     it('$collStats returns just storageStats', () => {
-      accepts({'$collStats': { storageStats: {}}});
+      accepts({ '$collStats': { storageStats: {} } });
     });
     it('$collStats returns all fields', () => {
       accepts(
-        {'$collStats': {
-          latencyStats: {histograms: true},
-          storageStats: {},
-          count: {}
-        }}
+        {
+          '$collStats': {
+            latencyStats: { histograms: true },
+            storageStats: {},
+            count: {}
+          }
+        }
       );
     });
     it('$currentOp returns an empty doc', () => {
       accepts({ '$currentOp': {} });
     });
     it('$currentOp returns just allUsers', () => {
-      accepts({ '$currentOp': { allUsers: true }});
+      accepts({ '$currentOp': { allUsers: true } });
     });
     it('$currentOp returns just idleConnections', () => {
-      accepts({'$currentOp': { idleConnections: false }});
+      accepts({ '$currentOp': { idleConnections: false } });
     });
     it('$currentOp returns all fields', () => {
       accepts(
-        {'$currentOp': { allUsers: true, idleConnections: false }}
+        { '$currentOp': { allUsers: true, idleConnections: false } }
       );
     });
     it('$lookup returns full doc', () => {
       accepts(
-        {'$lookup': {
-          from: 'fromColl', localField: 'inputField',
-          foreignField: 'fromField', as: 'outArray'
-        }}
+        {
+          '$lookup': {
+            from: 'fromColl', localField: 'inputField',
+            foreignField: 'fromField', as: 'outArray'
+          }
+        }
       );
     });
     it('supports let and pipeline', () => {
-      // accepts(
-      //   {'$lookup':
-      //     {
-      //       from: "warehouses",
-      //       let: { order_item: "$item", order_qty: "$ordered" },
-      //       pipeline: [
-      //          { '$match':
-      //             { '$expr':
-      //                { '$and':
-      //                   [
-      //                     { '$eq': [ "$stock_item",  "$$order_item" ] },
-      //                     { '$gte': [ "$instock", "$$order_qty" ] }
-      //                   ]
-      //                }
-      //             }
-      //          },
-      //          { '$project': { stock_item: 0, _id: 0 } }
-      //       ],
-      //       as: "stockdata"
-      //     }
-      //   });
-      // accepts({
-      //   '$lookup': { from: "warehouses", let: { order_item: "$item", order_qty: "$ordered"  }, pipeline: [{ '$match': { '$expr': { '$and': [{ '$eq': [ "$stock_item",  "$$order_item" ] }, { '$gte': [ "$instock", "$$order_qty" ] } ] } } }, { '$project': { stock_item: 0, _id: 0 } } ], as: "stockdata" }
-      // });
+      accepts(
+        {
+          '$lookup':
+          {
+            from: 'warehouses',
+            let: { order_item: '$item', order_qty: '$ordered' },
+            pipeline: [
+              {
+                '$match':
+                {
+                  '$expr':
+                  {
+                    '$and':
+                      [{ '$eq': ['$stock_item', '$$order_item'] }, { '$gte': ['$instock', '$$order_qty'] }]
+                  }
+                }
+              },
+              { '$project': { stock_item: 0, _id: 0 } }
+            ],
+            as: 'stockdata'
+          }
+        });
+    });
+    it('supports let and pipeline with size expression', () => {
+      accepts({
+        '$lookup': {
+          from: 'air_airlines',
+          let: { maybe_name: '$airlines' },
+          pipeline: [
+            {
+              '$match':
+                { '$expr': { '$gt': [{ '$size': { setIntersection: ['$$maybe_name', '$name', '$alias', '$iata', '$icao'] } }, 0] } }
+            },
+            {
+              '$project':
+              {
+                _id: 0,
+                name_is: '$name',
+                ref_name:
+                  { '$arrayElemAt': [{ '$filter': { input: '$$maybe_name', cond: { '$in': ['$$this', ['$name', '$alias', '$iata', '$icao']] } } }, 0] }
+              }
+            }],
+          as: 'found'
+        }
+      });
     });
     it('$geoNear returns full doc', () => {
       accepts(
-        {'$geoNear': {
-          minDistance: 10.1,
-          distanceField: 'toField',
-          spherical: true,
-          limit: 100,
-          num: 100,
-          uniqueDocs: true,
-          maxDistance: 100,
-          query: {x: 1},
-          distanceMultiplier: 100,
-          includeLocs: 'outputfield',
-          near: {type: 'Point', coordinates: [10.01, 9.99]}
-        }});
+        {
+          '$geoNear': {
+            minDistance: 10.1,
+            distanceField: 'toField',
+            spherical: true,
+            limit: 100,
+            num: 100,
+            uniqueDocs: true,
+            maxDistance: 100,
+            query: { x: 1 },
+            distanceMultiplier: 100,
+            includeLocs: 'outputfield',
+            near: { type: 'Point', coordinates: [10.01, 9.99] }
+          }
+        });
     });
     it('$geoNear returns the two required', () => {
       accepts(
-        {'$geoNear': {
-          near: {type: 'Point', coordinates: [10.01, 9.99]},
-          distanceField: 'field' }});
+        {
+          '$geoNear': {
+            near: { type: 'Point', coordinates: [10.01, 9.99] },
+            distanceField: 'field'
+          }
+        });
     });
     it('$geoNear returns legacy coordinates', () => {
       accepts(
-        {'$geoNear': {
-          near: [ 10.0001, -33.01 ],
-          distanceField: 'field'
-        }});
+        {
+          '$geoNear': {
+            near: [10.0001, -33.01],
+            distanceField: 'field'
+          }
+        });
     });
 
     it('$group returns a group with _id', () => {
       accepts({ '$group': { _id: 1, field1: { '$sum': 'field' } } });
     });
     it('$group returns an agg expr for _id', () => {
-      accepts({ '$group': { _id: {'$abs': 1}, field1: { '$sum': 'field' } } });
+      accepts({ '$group': { _id: { '$abs': 1 }, field1: { '$sum': 'field' } } });
     });
     it('$group returns an agg expr for accumulator', () => {
       accepts(
-        { '$group': { _id: {'$abs': 1}, field1: { '$sum': {'$abs': 1} } } });
+        { '$group': { _id: { '$abs': 1 }, field1: { '$sum': { '$abs': 1 } } } });
     });
     it('$graphLookup returns min doc', () => {
-      accepts({'$graphLookup': {
-        from: 'employees',
-        startWith: '$reportsTo',
-        connectFromField: 'reportsTo',
-        connectToField: 'name',
-        as: 'reportingHierarchy'
-      }});
+      accepts({
+        '$graphLookup': {
+          from: 'employees',
+          startWith: '$reportsTo',
+          connectFromField: 'reportsTo',
+          connectToField: 'name',
+          as: 'reportingHierarchy'
+        }
+      });
     });
     it('$graphLookup returns full doc', () => {
-      accepts({'$graphLookup': {
-        from: 'employees',
-        startWith: '$reportsTo',
-        connectFromField: 'reportsTo',
-        connectToField: 'name',
-        as: 'reportingHierarchy',
-        maxDepth: 100,
-        depthField: 'fieldname',
-        restrictSearchWithMatch: {x: 1}
-      }});
+      accepts({
+        '$graphLookup': {
+          from: 'employees',
+          startWith: '$reportsTo',
+          connectFromField: 'reportsTo',
+          connectToField: 'name',
+          as: 'reportingHierarchy',
+          maxDepth: 100,
+          depthField: 'fieldname',
+          restrictSearchWithMatch: { x: 1 }
+        }
+      });
     });
     it('$graphLookup returns an expression for startWith', () => {
-      accepts({'$graphLookup': {
-        from: 'employees',
-        startWith: {'$abs': 1},
-        connectFromField: 'reportsTo',
-        connectToField: 'name',
-        as: 'reportingHierarchy'
-      }});
+      accepts({
+        '$graphLookup': {
+          from: 'employees',
+          startWith: { '$abs': 1 },
+          connectFromField: 'reportsTo',
+          connectToField: 'name',
+          as: 'reportingHierarchy'
+        }
+      });
     });
     it('$graphLookup returns an array for startWith', () => {
-      accepts({'$graphLookup': {
-        from: 'employees',
-        startWith: ['f1', 'f2'],
-        connectFromField: 'reportsTo',
-        connectToField: 'name',
-        as: 'reportingHierarchy'
-      }});
+      accepts({
+        '$graphLookup': {
+          from: 'employees',
+          startWith: ['f1', 'f2'],
+          connectFromField: 'reportsTo',
+          connectToField: 'name',
+          as: 'reportingHierarchy'
+        }
+      });
     });
     it('$graphLookup returns an array for connectToField', () => {
-      accepts({'$graphLookup': {
-        from: 'employees',
-        startWith: ['f1', 'f2'],
-        connectFromField: 'reportsTo',
-        connectToField: ['name', 'name2'],
-        as: 'reportingHierarchy'
-      }});
+      accepts({
+        '$graphLookup': {
+          from: 'employees',
+          startWith: ['f1', 'f2'],
+          connectFromField: 'reportsTo',
+          connectToField: ['name', 'name2'],
+          as: 'reportingHierarchy'
+        }
+      });
     });
     it('$graphLookup returns query expr for restrictSearchWithMatch', () => {
-      accepts({'$graphLookup': {
-        from: 'employees',
-        startWith: '$reportsTo',
-        connectFromField: 'reportsTo',
-        connectToField: 'name',
-        as: 'reportingHierarchy',
-        restrictSearchWithMatch: {x: {'$gt': 1}}
-      }});
+      accepts({
+        '$graphLookup': {
+          from: 'employees',
+          startWith: '$reportsTo',
+          connectFromField: 'reportsTo',
+          connectToField: 'name',
+          as: 'reportingHierarchy',
+          restrictSearchWithMatch: { x: { '$gt': 1 } }
+        }
+      });
     });
     it('$graphLookup returns a regular doc', () => {
-      accepts({'$graphLookup': {
-        from: 'employees',
-        startWith: '$reportsTo',
-        connectFromField: 'reportsTo',
-        connectToField: 'name',
-        as: 'reportingHierarchy',
-        restrictSearchWithMatch: {x: 1}}});
-      accepts({'$graphLookup': {
-        from: 'employees',
-        startWith: '$reportsTo',
-        connectFromField: 'reportsTo',
-        connectToField: 'name',
-        as: 'reportingHierarchy',
-        restrictSearchWithMatch: {'x': 1}}});
+      accepts({
+        '$graphLookup': {
+          from: 'employees',
+          startWith: '$reportsTo',
+          connectFromField: 'reportsTo',
+          connectToField: 'name',
+          as: 'reportingHierarchy',
+          restrictSearchWithMatch: { x: 1 }
+        }
+      });
+      accepts({
+        '$graphLookup': {
+          from: 'employees',
+          startWith: '$reportsTo',
+          connectFromField: 'reportsTo',
+          connectToField: 'name',
+          as: 'reportingHierarchy',
+          restrictSearchWithMatch: { 'x': 1 }
+        }
+      });
     });
     it('$bucket returns min doc', () => {
-      accepts({'$bucket': {
-        groupBy: '$fieldname',
-        boundaries: [1, 2]
-      }});
+      accepts({
+        '$bucket': {
+          groupBy: '$fieldname',
+          boundaries: [1, 2]
+        }
+      });
     });
     it('$bucket returns an agg expr for groupBy', () => {
-      accepts({'$bucket': {
-        groupBy: {'$abs': 1},
-        boundaries: [1, 2]
-      }});
+      accepts({
+        '$bucket': {
+          groupBy: { '$abs': 1 },
+          boundaries: [1, 2]
+        }
+      });
     });
     it('$bucket returns full doc', () => {
-      accepts({'$bucket': {
-        groupBy: '$fieldname',
-        boundaries: [1, 2],
-        default: 'a string',
-        output: { output1: {'$sum': 1}, output2: {'$avg': 1} }
-      }});
+      accepts({
+        '$bucket': {
+          groupBy: '$fieldname',
+          boundaries: [1, 2],
+          default: 'a string',
+          output: { output1: { '$sum': 1 }, output2: { '$avg': 1 } }
+        }
+      });
     });
     it('$bucket returns literal in boundaries', () => {
-      accepts({'$bucket': {
-        groupBy: '$fieldname',
-        boundaries: [{'$literal': {x: 1}}, {'$literal': {x: 2}}],
-        default: 'a string',
-        output: { output1: {'$sum': 1}, output2: {'$avg': 1} }
-      }});
+      accepts({
+        '$bucket': {
+          groupBy: '$fieldname',
+          boundaries: [{ '$literal': { x: 1 } }, { '$literal': { x: 2 } }],
+          default: 'a string',
+          output: { output1: { '$sum': 1 }, output2: { '$avg': 1 } }
+        }
+      });
     });
     it('$bucket returns test doc', () => {
       accepts({
         '$bucket': {
           groupBy: '$price',
-          boundaries: [ 0, 150, 200, 300, 400 ],
+          boundaries: [0, 150, 200, 300, 400],
           default: 'Other',
           output: {
             'count': { '$sum': 1 },
             'titles': { '$push': '$title' }
-          }}
+          }
+        }
       });
     });
     it('$bucketAuto returns min doc', () => {
-      accepts({'$bucketAuto': {
-        groupBy: '$fieldname',
-        buckets: 10
-      }});
+      accepts({
+        '$bucketAuto': {
+          groupBy: '$fieldname',
+          buckets: 10
+        }
+      });
     });
     it('$bucketAuto returns an agg expr for groupBy', () => {
-      accepts({'$bucketAuto': {
-        groupBy: {'$abs': 1},
-        buckets: 10
-      }});
+      accepts({
+        '$bucketAuto': {
+          groupBy: { '$abs': 1 },
+          buckets: 10
+        }
+      });
     });
     it('$bucketAuto returns full doc', () => {
-      accepts({'$bucketAuto': {
-        groupBy: '$fieldname',
-        buckets: 10,
-        granularity: 'R80',
-        output: { output1: {'$sum': 1}, output2: {'$avg': 1} }
-      }});
+      accepts({
+        '$bucketAuto': {
+          groupBy: '$fieldname',
+          buckets: 10,
+          granularity: 'R80',
+          output: { output1: { '$sum': 1 }, output2: { '$avg': 1 } }
+        }
+      });
     });
     it('$bucketAuto returns literal in boundaries', () => {
-      accepts({'$bucketAuto': {
-        groupBy: '$fieldname',
-        buckets: 10,
-        granularity: 'R80',
-        output: { output1: {'$sum': 1}, output2: {'$avg': 1} }
-      }});
+      accepts({
+        '$bucketAuto': {
+          groupBy: '$fieldname',
+          buckets: 10,
+          granularity: 'R80',
+          output: { output1: { '$sum': 1 }, output2: { '$avg': 1 } }
+        }
+      });
     });
   });
 
@@ -350,113 +419,152 @@ describe('#parse', () => {
       );
     });
     it('returns an empty doc', () => {
-      accepts({'$listLocalSessions': {}});
+      accepts({ '$listLocalSessions': {} });
     });
     it('$listLocalSessions returns allUsers', () => {
-      accepts({'$listLocalSessions': {allUsers: true}});
+      accepts({ '$listLocalSessions': { allUsers: true } });
     });
     it('$listLocalSessions returns one user/db', () => {
-      accepts({'$listLocalSessions': {
-        users: [
-          { user: 'anna', db: 'test'}
-        ]
-      }});
+      accepts({
+        '$listLocalSessions': {
+          users: [
+            { user: 'anna', db: 'test' }
+          ]
+        }
+      });
     });
     it('$listLocalSessions returns multiple user/db', () => {
-      accepts({'$listLocalSessions': {users: [
-        {user: 'anna', db: 'test'}, {user: 'sara', db: 'test2'}]}});
+      accepts({
+        '$listLocalSessions': {
+          users: [
+            { user: 'anna', db: 'test' }, { user: 'sara', db: 'test2' }]
+        }
+      });
     });
     it('$listSessions returns an empty doc', () => {
-      accepts({'$listSessions': {}});
+      accepts({ '$listSessions': {} });
     });
     it('$listSessions returns allUsers', () => {
-      accepts({'$listSessions': {allUsers: true}});
+      accepts({ '$listSessions': { allUsers: true } });
     });
     it('$listSessions returns one user/db', () => {
-      accepts({'$listSessions': {users: [
-        {user: 'anna', db: 'test'}]}});
+      accepts({
+        '$listSessions': {
+          users: [
+            { user: 'anna', db: 'test' }]
+        }
+      });
     });
     it('$listSessions returns multiple user/db', () => {
-      accepts({'$listSessions': {
-        users: [{user: 'anna', db: 'test'}, {user: 'sara', db: 'test2'}]}});
+      accepts({
+        '$listSessions': {
+          users: [{ user: 'anna', db: 'test' }, { user: 'sara', db: 'test2' }]
+        }
+      });
     });
   });
 
   describe('expressions with unnamed fields', () => {
     it('$addFields returns multiple fields', () => {
-      accepts({'$addFields': {
-        field1: 'value1',
-        field2: 1,
-        field3: {x: 1}
-      }});
+      accepts({
+        '$addFields': {
+          field1: 'value1',
+          field2: 1,
+          field3: { x: 1 }
+        }
+      });
     });
     it('$addFields returns one field', () => {
-      accepts({'$addFields': {
-        field1: 'value1'
-      }});
+      accepts({
+        '$addFields': {
+          field1: 'value1'
+        }
+      });
     });
     it('$addFields returns agg expr', () => {
-      accepts({'$addFields': {
-        field1: {$abs: 100}
-      }});
+      accepts({
+        '$addFields': {
+          field1: { $abs: 100 }
+        }
+      });
     });
     it('$addFields returns a nested field', () => {
-      accepts({'$addFields': {
-        'field1.subfield': {'$abs': 100}
-      }});
+      accepts({
+        '$addFields': {
+          'field1.subfield': { '$abs': 100 }
+        }
+      });
     });
     it('$sort returns multiple fields', () => {
-      accepts({'$sort': {
-        field1: 1,
-        field2: -1,
-        field3: {$meta: 'textScore'}
-      }});
+      accepts({
+        '$sort': {
+          field1: 1,
+          field2: -1,
+          field3: { $meta: 'textScore' }
+        }
+      });
     });
     it('$sort returns meta sort order', () => {
-      accepts({'$sort': {
-        field: {'$meta': 'textScore'}
-      }});
+      accepts({
+        '$sort': {
+          field: { '$meta': 'textScore' }
+        }
+      });
     });
     it('$sort returns one field', () => {
-      accepts({'$sort': {
-        field: 1
-      }});
+      accepts({
+        '$sort': {
+          field: 1
+        }
+      });
     });
     it('$match returns a simple document', () => {
-      accepts({'$match': {
-        x: 1, y: {q: 1}, z: 'testing'
-      }});
+      accepts({
+        '$match': {
+          x: 1, y: { q: 1 }, z: 'testing'
+        }
+      });
     });
     it('$match returns a nested field', () => {
-      accepts({'$match': {
-        'x.y.z': 1, y: {q: 1}, z: 'testing'
-      }});
+      accepts({
+        '$match': {
+          'x.y.z': 1, y: { q: 1 }, z: 'testing'
+        }
+      });
     });
     it('$match returns $or', () => {
-      accepts({'$match': {
-        '$or': [{x: 1}, {y: 1}]
-      }});
+      accepts({
+        '$match': {
+          '$or': [{ x: 1 }, { y: 1 }]
+        }
+      });
     });
     it('$match returns $and', () => {
-      accepts({'$match': {
-        '$and': [{z: 30}, {r: 99}]
-      }});
+      accepts({
+        '$match': {
+          '$and': [{ z: 30 }, { r: 99 }]
+        }
+      });
     });
     it('$match returns $expr', () => {
-      accepts({'$match': {
-        '$expr': [{z: 30}, {r: 99}]
-      }});
+      accepts({
+        '$match': {
+          '$expr': [{ z: 30 }, { r: 99 }]
+        }
+      });
     });
     it('$match returns an empty document', () => {
-      accepts({'$match': {}});
+      accepts({ '$match': {} });
     });
     it('$match returns accumulators within $or', () => {
-      accepts({'$match': {
-        '$or': [
-          { score: { '$gt': 70, '$lt': 90 } },
-          { x: { '$lt': 70 } }
-        ]
-      }});
+      accepts({
+        '$match': {
+          '$or': [
+            { score: { '$gt': 70, '$lt': 90 } },
+            { x: { '$lt': 70 } }
+          ]
+        }
+      });
     });
     it('$match returns query operators', () => {
       accepts({ '$match': { x: { '$gt': 70 } } });
@@ -477,46 +585,62 @@ describe('#parse', () => {
       });
     });
     it('$project returns a included field', () => {
-      accepts({'$project': {
-        testfield: 1,
-        testfield2: true
-      }});
+      accepts({
+        '$project': {
+          testfield: 1,
+          testfield2: true
+        }
+      });
     });
     it('$project returns a excluded field', () => {
-      accepts({'$project': {
-        testfield: 0,
-        testfield2: false
-      }});
+      accepts({
+        '$project': {
+          testfield: 0,
+          testfield2: false
+        }
+      });
     });
     it('$project returns a excluded _id field', () => {
-      accepts({'$project': {
-        _id: 0
-      }});
+      accepts({
+        '$project': {
+          _id: 0
+        }
+      });
     });
     it('$project returns an agg expr', () => {
-      accepts({'$project': {
-        field: {'$literal': 'testing'}
-      }});
+      accepts({
+        '$project': {
+          field: { '$literal': 'testing' }
+        }
+      });
     });
     it('$project returns nested field', () => {
-      accepts({'$project': {
-        'field.nested': '$new.field.name'
-      }});
+      accepts({
+        '$project': {
+          'field.nested': '$new.field.name'
+        }
+      });
     });
     it('$project returns nested field without quotes', () => {
-      accepts({'$project': {
-        'field.nested': {'$literal': 'testing'}
-      }});
+      accepts({
+        '$project': {
+          'field.nested': { '$literal': 'testing' }
+        }
+      });
     });
     it('$project returns fields with whitespace', () => {
-      accepts({'$project': {
-        '    fie   ld.nm   ested    ': '$new.field.name'
-      }});
+      accepts({
+        '$project': {
+          '    fie   ld.nm   ested    ': '$new.field.name'
+        }
+      });
     });
     it('$project returns backslashes', () => {
-      accepts({'$project': {
-        'field\?': '$new.field.name'
-      }});
+      accepts({
+        '$project': {
+          'field\?': '$new.field.name'
+        }
+      });
     });
     it('$project accepts cond', () => {
       accepts({
@@ -526,7 +650,7 @@ describe('#parse', () => {
           'author.last': 1,
           'author.middle': {
             '$cond': {
-              if: { $eq: [ '', '$author.middle' ] },
+              if: { $eq: ['', '$author.middle'] },
               then: '$$REMOVE',
               else: '$author.middle'
             }
@@ -538,19 +662,19 @@ describe('#parse', () => {
       accepts({
         '$facet': {
           'categorizedByTags': [
-            {'$unwind': '$tags'},
-            {'$sortByCount': '$tags'}
+            { '$unwind': '$tags' },
+            { '$sortByCount': '$tags' }
           ],
           'categorizedByPrice': [
-            {'$match': {price: {'$exists': 1}}},
+            { '$match': { price: { '$exists': 1 } } },
             {
               '$bucket': {
                 groupBy: '$price',
                 boundaries: [0, 150, 200, 300, 400],
                 default: 'Other',
                 output: {
-                  'count': {'$sum': 1},
-                  'titles': {'$push': '$title'}
+                  'count': { '$sum': 1 },
+                  'titles': { '$push': '$title' }
                 }
               }
             }
@@ -571,58 +695,78 @@ describe('#parse', () => {
   describe('Key syntax', () => {
     describe('field', () => {
       it('returns a field with $ or . later on in quotes', () => {
-        accepts({$addFields: {
-          't.fiel$d1': 'value1'
-        }});
+        accepts({
+          $addFields: {
+            't.fiel$d1': 'value1'
+          }
+        });
       });
       it('returns a fieldname with space and quotes', () => {
-        accepts({$addFields: {
-          'fiel d1': 'value1'
-        }});
+        accepts({
+          $addFields: {
+            'fiel d1': 'value1'
+          }
+        });
       });
       it('returns a fieldname with escaped characters', () => {
-        accepts({$addFields: {
-          '\tfiel d\r1': 'value1'
-        }});
+        accepts({
+          $addFields: {
+            '\tfiel d\r1': 'value1'
+          }
+        });
       });
       it('returns a nested field name', () => {
-        accepts({$addFields: {
-          'name.name2': 'value1'
-        }});
+        accepts({
+          $addFields: {
+            'name.name2': 'value1'
+          }
+        });
       });
       it('returns an escaped double quote', () => {
-        accepts({$addFields: {
-          'fiel"d1': 'value1'
-        }});
+        accepts({
+          $addFields: {
+            'fiel"d1': 'value1'
+          }
+        });
       });
       it('returns an escaped single quote', () => {
-        accepts({$addFields: {
-          'fiel\'d1': 'value1'
-        }});
+        accepts({
+          $addFields: {
+            'fiel\'d1': 'value1'
+          }
+        });
       });
       it('returns an double quote within single quotes', () => {
-        accepts({$addFields: {
-          "fiel'd1": 'value1'
-        }});
+        accepts({
+          $addFields: {
+            "fiel'd1": 'value1'
+          }
+        });
       });
       it('returns an single quote within double quotes', () => {
-        accepts({$addFields: {
-          'fiel"d1': 'value1'
-        }});
+        accepts({
+          $addFields: {
+            'fiel"d1': 'value1'
+          }
+        });
       });
       it('returns unicode', () => {
-        accepts({$addFields: {
-          'fiel☂d1': 'value1'
-        }});
+        accepts({
+          $addFields: {
+            'fiel☂d1': 'value1'
+          }
+        });
       });
     });
     describe('object', () => {
       it('returns an object', () => {
-        accepts({$lookup: {
-          from: 'fromColl', localField: 'inputField',
-          foreignField: 'fromField', as: 'outArray',
-          let: { test: 'value' }
-        }}
+        accepts({
+          $lookup: {
+            from: 'fromColl', localField: 'inputField',
+            foreignField: 'fromField', as: 'outArray',
+            let: { test: 'value' }
+          }
+        }
         );
       });
     });
@@ -630,83 +774,92 @@ describe('#parse', () => {
       it('returns all operators', () => {
         accepts({
           $match: {
-            a: {$eq: 1}, b: {$gt: 1}, c: {$gte: 1}, d: {$in: 1}, e: {$lt: 1},
-            f2: {$lte: 1}, g: {$ne: 1}, f: {$nin: 1},
-            g2: {$and: 1}, h: {$or: 1}, i: {$not: 1}, j: {$nor: 1},
-            k: {$exists: 1}, l: {$type: 1},
-            m: {$expr: 1}, n: {$jsonSchema: 1}, o: {$mod: 1}, p: {$regex: 1},
-            q: {$text: 1}, r: {$where: 1},
-            s: {$geoIntersects: 1}, t: {$geoWithin: 1},
-            v: {$nearSphere: 1}, u: {$near: 1},
-            w: {$all: 1}, x: {$elemMatch: 1}, y: {$size: 1},
-            z: {$bitsAllClear: 1}, a1: {$bitsAllSet: 1}, b1: {$bitsAnyClear: 1},
-            c1: {$bitsAnySet: 1}, d1: {$comment: 1},
-            e1: {$elemMatch: 1}, f1: {$meta: 1}, g1: {$slice: 1}
-          }});
+            a: { $eq: 1 }, b: { $gt: 1 }, c: { $gte: 1 }, d: { $in: 1 }, e: { $lt: 1 },
+            f2: { $lte: 1 }, g: { $ne: 1 }, f: { $nin: 1 },
+            g2: { $and: 1 }, h: { $or: 1 }, i: { $not: 1 }, j: { $nor: 1 },
+            k: { $exists: 1 }, l: { $type: 1 },
+            m: { $expr: 1 }, n: { $jsonSchema: 1 }, o: { $mod: 1 }, p: { $regex: 1 },
+            q: { $text: 1 }, r: { $where: 1 },
+            s: { $geoIntersects: 1 }, t: { $geoWithin: 1 },
+            v: { $nearSphere: 1 }, u: { $near: 1 },
+            w: { $all: 1 }, x: { $elemMatch: 1 }, y: { $size: 1 },
+            z: { $bitsAllClear: 1 }, a1: { $bitsAllSet: 1 }, b1: { $bitsAnyClear: 1 },
+            c1: { $bitsAnySet: 1 }, d1: { $comment: 1 },
+            e1: { $elemMatch: 1 }, f1: { $meta: 1 }, g1: { $slice: 1 }
+          }
+        });
       });
       it('returns one op with quotes', () => {
-        accepts({ $match: { x: {'$lte': 1} } });
+        accepts({ $match: { x: { '$lte': 1 } } });
       });
       it('returns non-operator fields', () => {
         accepts({
-          $match: {x: 100}});
+          $match: { x: 100 }
+        });
       });
     });
     describe('agg_expr', () => {
       it('returns all operators without quotes part 1', () => {
-        accepts({$addFields: {
-          aa: {$abs: 1}, a3: {$cond: 1}, a4: {$gt: 1}, a5: {$gte: 1},
-          a6: {$lt: 1}, a7: {$lte: 1}, a8: {$in: 1}, a: {$addToSet: 1},
-          q: {$and: 1}, w: {$avg: 1}, e: {$eq: 1}, r: {$first: 1},
-          t: {$gte: 1}, y: {$gt: 1}, u: {$lte: 1}, i: {$lt: 1}, o: {$in: 1},
-          p: {$last: 1}, a2: {$meta: 1}, s: {$max: 1}, d: {$min: 1},
-          f: {$mod: 1}, g: {$ne: 1}, h: {$not: 1}, j: {$or: 1}, j2: {$push: 1},
-          k: {$size: 1}, l: {$slice: 1}, z: {$stdDevPop: 1},
-          x: {$stdDevSamp: 1}, c: {$sum: 1}, v: {$type: 1}, v2: {$abs: 1},
-          b: {$add: 1}, n: {$allElementsTrue: 1}, m: {$anyElementTrue: 1},
-          m1: {$arrayElemAt: 1}, 11: {$arrayToObject: 1}, 2: {$ceil: 1},
-          3: {$cmp: 1}, 4: {$concatArrays: 1}, 5: {$concat: 1},
-          6: {$dateFromParts: 1}, 7: {$dateFromString: 1},
-          8: {$dateToString: 1}, 9: {$dateToParts: 1}, 0: {$dayOfMonth: 1}
-        }});
+        accepts({
+          $addFields: {
+            aa: { $abs: 1 }, a3: { $cond: 1 }, a4: { $gt: 1 }, a5: { $gte: 1 },
+            a6: { $lt: 1 }, a7: { $lte: 1 }, a8: { $in: 1 }, a: { $addToSet: 1 },
+            q: { $and: 1 }, w: { $avg: 1 }, e: { $eq: 1 }, r: { $first: 1 },
+            t: { $gte: 1 }, y: { $gt: 1 }, u: { $lte: 1 }, i: { $lt: 1 }, o: { $in: 1 },
+            p: { $last: 1 }, a2: { $meta: 1 }, s: { $max: 1 }, d: { $min: 1 },
+            f: { $mod: 1 }, g: { $ne: 1 }, h: { $not: 1 }, j: { $or: 1 }, j2: { $push: 1 },
+            k: { $size: 1 }, l: { $slice: 1 }, z: { $stdDevPop: 1 },
+            x: { $stdDevSamp: 1 }, c: { $sum: 1 }, v: { $type: 1 }, v2: { $abs: 1 },
+            b: { $add: 1 }, n: { $allElementsTrue: 1 }, m: { $anyElementTrue: 1 },
+            m1: { $arrayElemAt: 1 }, 11: { $arrayToObject: 1 }, 2: { $ceil: 1 },
+            3: { $cmp: 1 }, 4: { $concatArrays: 1 }, 5: { $concat: 1 },
+            6: { $dateFromParts: 1 }, 7: { $dateFromString: 1 },
+            8: { $dateToString: 1 }, 9: { $dateToParts: 1 }, 0: { $dayOfMonth: 1 }
+          }
+        });
       });
       it('returns all operators part 2', () => {
-        accepts({$addFields: {
-          q: {$dayOfWeek: 1}, w: {$dayOfYear: 1}, e: {$divide: 1},
-          r: {$exp: 1}, t: {$filter: 1}, y: {$floor: 1}, u: {$hour: 1},
-          i: {$ifNull: 1}, a1: {$isArray: 1}, o: {$indexOfBytes: 1},
-          p: {$indexOfArray: 1}, a: {$indexOfCP: 1}, s: {$isoDayOfWeek: 1},
-          d: {$isoWeek: 1}, f: {$isoWeekYear: 1}, g: {$let: 1},
-          g1: {$literal: 1}, h: {$ln: 1}, j: {$log10: 1}, k: {$log: 1},
-          l: {$map: 1}, z: {$mergeObjects: 1}, z1: {$millisecond: 1},
-          x: {$minute: 1}, c: {$month: 1}, v: {$multiply: 1},
-          b: {$objectToArray: 1}, n: {$pow: 1}, m: {$range: 1},
-          m2: {$reduce: 1}, 1: {$reverseArray: 1}, 2: {$second: 1},
-          3: {$setDifference: 1}, 4: {$setEquals: 1}, 5: {$setIntersection: 1},
-          6: {$setIsSubset: 1}, 7: {$setUnion: 1}, 8: {$split: 1}, 9: {$sqrt: 1},
-          0: {$strcasecmp: 1}, 11: {$strLenBytes: 1}, 22: {$strLenCP: 1},
-          33: {$substrBytes: 1}, 44: {$substrCP: 1}, 55: {$substr: 1},
-          77: {$subtract: 1}, 88: {$switch: 1}, 99: {$toLower: 1},
-          aa: {$toUpper: 1}, ss: {$trunc: 1}, dd: {$week: 1}, ff: {$year: 1},
-          gg: {$zip: 1}
-        }});
+        accepts({
+          $addFields: {
+            q: { $dayOfWeek: 1 }, w: { $dayOfYear: 1 }, e: { $divide: 1 },
+            r: { $exp: 1 }, t: { $filter: 1 }, y: { $floor: 1 }, u: { $hour: 1 },
+            i: { $ifNull: 1 }, a1: { $isArray: 1 }, o: { $indexOfBytes: 1 },
+            p: { $indexOfArray: 1 }, a: { $indexOfCP: 1 }, s: { $isoDayOfWeek: 1 },
+            d: { $isoWeek: 1 }, f: { $isoWeekYear: 1 }, g: { $let: 1 },
+            g1: { $literal: 1 }, h: { $ln: 1 }, j: { $log10: 1 }, k: { $log: 1 },
+            l: { $map: 1 }, z: { $mergeObjects: 1 }, z1: { $millisecond: 1 },
+            x: { $minute: 1 }, c: { $month: 1 }, v: { $multiply: 1 },
+            b: { $objectToArray: 1 }, n: { $pow: 1 }, m: { $range: 1 },
+            m2: { $reduce: 1 }, 1: { $reverseArray: 1 }, 2: { $second: 1 },
+            3: { $setDifference: 1 }, 4: { $setEquals: 1 }, 5: { $setIntersection: 1 },
+            6: { $setIsSubset: 1 }, 7: { $setUnion: 1 }, 8: { $split: 1 }, 9: { $sqrt: 1 },
+            0: { $strcasecmp: 1 }, 11: { $strLenBytes: 1 }, 22: { $strLenCP: 1 },
+            33: { $substrBytes: 1 }, 44: { $substrCP: 1 }, 55: { $substr: 1 },
+            77: { $subtract: 1 }, 88: { $switch: 1 }, 99: { $toLower: 1 },
+            aa: { $toUpper: 1 }, ss: { $trunc: 1 }, dd: { $week: 1 }, ff: { $year: 1 },
+            gg: { $zip: 1 }
+          }
+        });
       });
       it('returns accumulators', () => {
         accepts({
           $addFields: {
-            x: {$sum: 100}
-          }});
+            x: { $sum: 100 }
+          }
+        });
         accepts({
           $addFields: {
-            x: {'$sum': 100}
-          }});
+            x: { '$sum': 100 }
+          }
+        });
         accepts({
           $addFields: {
-            x: {'$sum': 100}
-          }});
+            x: { '$sum': 100 }
+          }
+        });
       });
       it('returns non-operator fields', () => {
-        accepts({$addFields: {x: 100}});
+        accepts({ $addFields: { x: 100 } });
       });
     });
   });


### PR DESCRIPTION
Sometimes `$size` queries need to have access to agg_array expressions, such as `$setIntersection`. Changing peg.js grammar to allow that.  

_EDIT:_ also fixed the eslint check that was failing